### PR TITLE
Enable double-click auto equip

### DIFF
--- a/src/core/EventBus.ts
+++ b/src/core/EventBus.ts
@@ -54,9 +54,10 @@ export interface GameEvents {
 	"classCard:levelUp": string;
 	"inventory:changed": void;
 	"inventory:dropped": string[];
-	"slot:drop": { fromId: string; toId: string };
-	"slot:drag-start": { slotId: string };
-	"slot:click": string;
+        "slot:drop": { fromId: string; toId: string };
+        "slot:drag-start": { slotId: string };
+        "slot:click": string;
+        "slot:dblclick": string;
 
 	"settlement:changed": void;
 	"settlement:buildPointsChanged": number;

--- a/src/features/inventory/InventoryManager.ts
+++ b/src/features/inventory/InventoryManager.ts
@@ -151,10 +151,32 @@ export class InventoryManager implements Saveable {
 			bus.emit("player:classCardsChanged", this.getEquippedCards());
 		}
 
-		return true;
-	}
+                return true;
+        }
 
-	public expandInventorySize(by: number) {
+        /**
+         * Automatically move an item from an inventory slot to the
+         * appropriate equipment or class card slot.
+         */
+        public autoEquip(fromId: string): boolean {
+                const from = this.getSlot(fromId);
+                if (!from || from.type !== "inventory" || !from.itemState) return false;
+
+                const spec = InventoryRegistry.getItemById(from.itemState.specId);
+                if (isEquipmentItemSpec(spec)) {
+                        const target = this.getSlot(`equipment-${spec.equipType}`);
+                        if (!target) return false;
+                        return this.moveItem(fromId, target.id);
+                }
+                if (spec.category === "classCard") {
+                        const cardSlot = this.getSlotsByType("classCard")[0];
+                        if (!cardSlot) return false;
+                        return this.moveItem(fromId, cardSlot.id);
+                }
+                return false;
+        }
+
+        public expandInventorySize(by: number) {
 		const start = this.slots.filter((s) => s.type === "inventory").length;
 		for (let i = 0; i < by; i++) {
 			this.slots.push(this.makeSlot("inventory", start + i));

--- a/src/ui/Screens/InventoryScreen.ts
+++ b/src/ui/Screens/InventoryScreen.ts
@@ -21,13 +21,17 @@ export class InventoryScreen extends BaseScreen {
 	show() {}
 	hide() {}
 
-	private bindEvents() {
-		bindEvent(this.eventBindings, "slot:drop", ({ fromId, toId }) => {
-			const changed = this.context.inventory.moveItem(fromId, toId);
-			if (changed) bus.emit("inventory:changed");
-		});
-		bindEvent(this.eventBindings, "inventory:changed", () => this.renderInventory());
-	}
+        private bindEvents() {
+                bindEvent(this.eventBindings, "slot:drop", ({ fromId, toId }) => {
+                        const changed = this.context.inventory.moveItem(fromId, toId);
+                        if (changed) bus.emit("inventory:changed");
+                });
+                bindEvent(this.eventBindings, "slot:dblclick", (slotId) => {
+                        const changed = this.context.inventory.autoEquip(slotId);
+                        if (changed) bus.emit("inventory:changed");
+                });
+                bindEvent(this.eventBindings, "inventory:changed", () => this.renderInventory());
+        }
 
 	private renderInventory() {
 		const inventory = this.context.inventory.getSlots();

--- a/src/ui/components/InventorySlot.ts
+++ b/src/ui/components/InventorySlot.ts
@@ -29,6 +29,7 @@ export class InventorySlot extends UIBase {
         this.bindDomEvent("mouseenter", (e) => this.handleMouseEnter());
         this.bindDomEvent("mouseleave", (e) => this.handleMouseLeave());
         this.bindDomEvent("click", (e) => this.handleClick());
+        this.bindDomEvent("dblclick", (e) => this.handleDoubleClick());
     }
 
     private handleMouseEnter() {
@@ -87,6 +88,9 @@ export class InventorySlot extends UIBase {
     }
     private handleClick() {
         bus.emit("slot:click", this.slotId);
+    }
+    private handleDoubleClick() {
+        bus.emit("slot:dblclick", this.slotId);
     }
 
     update(itemState: InventoryItemState | null) {


### PR DESCRIPTION
## Summary
- handle `slot:dblclick` event in `EventBus`
- emit `slot:dblclick` from inventory slots
- auto-equip items from inventory on double click
- wire up auto equip in inventory screen

## Testing
- `npm run build` *(fails: existing TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6842a723c3f88330bbd2d6b195a60fb1