### PR TITLE
Apply rarity scaling to equipment

### DIFF
--- a/src/models/Equipment.ts
+++ b/src/models/Equipment.ts
@@ -2,6 +2,8 @@ import { EquipmentItemSpec, InventoryItemState, UpgradableItem } from "@/shared/
 import { SpecRegistryBase } from "./SpecRegistryBase";
 import { UpgradeCalculator } from "./UpgradeCalculator";
 import { bus } from "@/core/EventBus";
+import { StatsModifier } from "./Stats";
+import { scaleStatsModifier } from "@/shared/utils/stat-utils";
 
 export class Equipment extends SpecRegistryBase<EquipmentItemSpec> implements EquipmentItemSpec, UpgradableItem {
     readonly category = "equipment";
@@ -39,6 +41,13 @@ export class Equipment extends SpecRegistryBase<EquipmentItemSpec> implements Eq
 
     get statMod() {
         return this.spec.statMod;
+    }
+
+    /**
+     * Stat bonuses after applying rarity multiplier
+     */
+    public getBonuses(): StatsModifier {
+        return scaleStatsModifier(this.spec.statMod, this.rarity ?? "common");
     }
 
     toJSON() {

--- a/src/models/EquipmentManager.ts
+++ b/src/models/EquipmentManager.ts
@@ -4,7 +4,7 @@
 import { bus } from "@/core/EventBus";
 import { StatsModifier } from "@/models/Stats";
 import { Equipment } from "./Equipment";
-import { mergeStatModifiers, scaleStatsModifier } from "@/shared/utils/stat-utils";
+import { mergeStatModifiers } from "@/shared/utils/stat-utils";
 import { GameContext } from "@/core/GameContext";
 import { Destroyable } from "./Destroyable";
 
@@ -26,9 +26,9 @@ export class EquipmentManager extends Destroyable {
 		const equippedItems = this.getEquippedEquipment();
 
 		// Calculate total stat bonuses from equipment
-		const statBonuses = equippedItems
-			.map((eq) => scaleStatsModifier(eq.statMod, eq.rarity ?? "common"))
-			.reduce(mergeStatModifiers, {} as StatsModifier);
+                const statBonuses = equippedItems
+                        .map((eq) => eq.getBonuses())
+                        .reduce(mergeStatModifiers, {} as StatsModifier);
 
 		// Apply to character if we have an active run
 		if (this.context.currentRun) {

--- a/src/ui/components/InventorySlot.ts
+++ b/src/ui/components/InventorySlot.ts
@@ -7,6 +7,7 @@ import { UIBase } from "./UIBase";
 import { InventoryRegistry } from "@/features/inventory/InventoryRegistry";
 import { isEquipmentItemSpec } from "@/shared/type-guards";
 import { StatsModifier } from "@/models/Stats";
+import { scaleStatsModifier } from "@/shared/utils/stat-utils";
 
 /** Pure UI component – no game logic */
 export class InventorySlot extends UIBase {
@@ -40,8 +41,12 @@ export class InventorySlot extends UIBase {
             // Now TypeScript knows this.spec is an EquipmentSpec
             const equipmentSpec = this.spec as EquipmentItemSpec;
 
-            // Prepare stat modifiers for display
-            const statModifiers = this.formatStatModifiers(equipmentSpec.statMod);
+            // Apply rarity scaling to stats for tooltip display
+            const scaled = scaleStatsModifier(
+                equipmentSpec.statMod,
+                this.itemState.rarity ?? "common",
+            );
+            const statModifiers = this.formatStatModifiers(scaled);
 
             Tooltip.instance.show(this.element, {
                 icon: this.spec.iconUrl,


### PR DESCRIPTION
## Summary
- factor rarity into equipment stat bonuses
- display scaled stats on item tooltips
- use new bonus helper when summing equipment bonuses

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d589d1948330bf6b20923ee3a86d