### PR TITLE
add outpost state to StatsManager

### DIFF
--- a/src/shared/stats-types.ts
+++ b/src/shared/stats-types.ts
@@ -65,6 +65,9 @@ export const DEFAULT_PRESTIGE_STATS: PrestigeStats = {};
 export const DEFAULT_OUTPOST_STATS: OutpostStats = {};
 
 export const DEFAULT_AREA_STATS: AreaStats = {
+    areaUnlocked: false,
+    outpostAvailable: false,
+    outpostBuilt: false,
     killsTotal: 0,
     killsThisRun: 0,
     bossUnlockedEver: false,


### PR DESCRIPTION
## Summary
- include outpost tracking in `AreaStats`
- store outpost availability and build status through `StatsManager`
- listen for outpost events in `StatsManager` and expose helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68456d610a1883308ac64ac50b1fccf6