### PR TITLE
Add initial library research system

### DIFF
--- a/css/library.css
+++ b/css/library.css
@@ -1,0 +1,90 @@
+/* Library Screen styles */
+.library-page {
+    display: flex;
+    gap: 1.5rem;
+    padding: 1.5rem;
+    width: 100%;
+}
+.library-left {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+.library-section-header {
+    font-size: 1.3rem;
+    font-weight: 600;
+    color: var(--primary-text, #fff);
+}
+.library-active-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 22px;
+    padding: 1rem 1.5rem;
+    backdrop-filter: blur(12px);
+}
+.library-research-row {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.8rem 0.5rem;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.07);
+}
+.library-research-icon {
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255, 255, 255, 0.22);
+    border-radius: 12px;
+    font-size: 1.8rem;
+}
+.library-research-info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+.library-research-title {
+    font-weight: 500;
+}
+.library-right {
+    width: 250px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 22px;
+    padding: 1rem;
+}
+.library-completed-header {
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+.library-completed-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+.library-upgrade-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+}
+.library-upgrade-card {
+    background: rgba(255, 255, 255, 0.14);
+    padding: 1rem;
+    border-radius: 16px;
+    cursor: pointer;
+}
+.library-upgrade-title {
+    font-size: 0.9rem;
+    font-weight: 500;
+}

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <link rel="stylesheet" href="/css/settlement.css" />
     <link rel="stylesheet" href="/css/UIComponents.css" />
     <link rel="stylesheet" href="/css/mine.css" />
+    <link rel="stylesheet" href="/css/library.css" />
 
 </head>
 

--- a/src/core/GameContext.ts
+++ b/src/core/GameContext.ts
@@ -8,6 +8,7 @@ import { PlayerCharacter } from "@/models/PlayerCharacter";
 import { HuntManager } from "@/features/hunt/HuntManager";
 import { InventoryManager } from "@/features/inventory/InventoryManager";
 import { SettlementManager } from "@/features/settlement/SettlementManager";
+import { LibraryManager } from "@/features/settlement/LibraryManager";
 import { bus } from "./EventBus";
 import { SaveManager } from "./SaveManager";
 import { ScreenManager } from "./ScreenManager";
@@ -81,9 +82,13 @@ export class GameContext {
 		return this.services.inventoryManager;
 	}
 
-	public get settlement(): SettlementManager {
-		return this.services.settlementManager;
-	}
+        public get settlement(): SettlementManager {
+                return this.services.settlementManager;
+        }
+
+        public get library(): LibraryManager {
+                return this.services.libraryManager;
+        }
 
 	public get saves(): SaveManager {
 		return this.services.saveManager;

--- a/src/core/GameServices.ts
+++ b/src/core/GameServices.ts
@@ -8,6 +8,9 @@ import { SettlementManager } from "@/features/settlement/SettlementManager";
 import { StatsManager } from "@/models/StatsManager";
 import { MilestoneManager } from "@/models/MilestoneManager";
 import { OfflineProgressManager } from "@/models/OfflineProgress";
+import { LibraryManager } from "@/features/settlement/LibraryManager";
+import rawResearch from "@/data/research.json" assert { type: "json" };
+import { ResearchSpec } from "@/shared/types";
 
 export class GameServices {
 	private static _instance: GameServices;
@@ -20,7 +23,8 @@ export class GameServices {
 
 	// Persistent managers that survive prestige
 	public readonly inventoryManager: InventoryManager;
-	public readonly settlementManager: SettlementManager;
+        public readonly settlementManager: SettlementManager;
+        public readonly libraryManager: LibraryManager;
 
 	private constructor() {
 		this.saveManager = new SaveManager();
@@ -28,8 +32,10 @@ export class GameServices {
 		this.statsManager = StatsManager.instance;
 		this.milestoneManager = MilestoneManager.instance;
 		this.inventoryManager = new InventoryManager();
-		this.settlementManager = new SettlementManager();
-		this.offlineManager = new OfflineProgressManager();
+                this.settlementManager = new SettlementManager();
+                this.libraryManager = new LibraryManager();
+                this.libraryManager.registerResearch(rawResearch as ResearchSpec[]);
+                this.offlineManager = new OfflineProgressManager();
 	}
 
 	static getInstance(): GameServices {

--- a/src/core/gameData.ts
+++ b/src/core/gameData.ts
@@ -5,6 +5,7 @@ import rawAbilities from "@/data/abilities.json" assert { type: "json" };
 import rawClassCards from "@/data/classCards.json" assert { type: "json" };
 import rawEquipment from "@/data/equipment.json" assert { type: "json" };
 import rawBuilding from "@/data/buildings.json" assert { type: "json" };
+import rawResearch from "@/data/research.json" assert { type: "json" };
 import rawTriggers from "@/data/progression-triggers.json" assert { type: "json" };
 import rawOutposts from "@/data/outposts.json" assert { type: "json" };
 
@@ -14,11 +15,12 @@ import { Monster, MonsterSpec } from "@/models/Monster";
 import { Ability, AbilitySpec } from "@/models/Ability";
 import { ClassCard } from "@/features/classcards/ClassCard";
 import { Equipment } from "@/models/Equipment";
-import { ClassCardItemSpec, EquipmentItemSpec, OutpostSpec, ProgressionTrigger } from "@/shared/types";
+import { ClassCardItemSpec, EquipmentItemSpec, OutpostSpec, ProgressionTrigger, ResearchSpec } from "@/shared/types";
 import { InventoryRegistry } from "@/features/inventory/InventoryRegistry";
 import { Building } from "@/features/settlement/Building";
 import { MilestoneManager } from "@/models/MilestoneManager";
 import { Outpost } from "@/features/hunt/Outpost";
+import { ResearchUpgrade } from "@/features/settlement/ResearchUpgrade";
 
 /* ---------- Register Data ---------------------------- */
 
@@ -28,6 +30,7 @@ export function initGameData() {
     console.log("📦 Registering game data…");
 
     Building.registerSpecs(rawBuilding);
+    ResearchUpgrade.registerSpecs(rawResearch as ResearchSpec[]);
     Equipment.registerSpecs(rawEquipment as EquipmentItemSpec[]);
     ClassCard.registerSpecs(rawClassCards as ClassCardItemSpec[]);
     Monster.registerSpecs(rawMonsters as MonsterSpec[]);

--- a/src/data/buildings.json
+++ b/src/data/buildings.json
@@ -27,11 +27,11 @@
 		"icon": "",
 		"baseCost": 200
 	},
-	{
-		"id": "library",
-		"displayName": "Library",
-		"description": "Library todo",
-		"icon": "",
-		"baseCost": 200
-	}
+        {
+                "id": "library",
+                "displayName": "Library",
+                "description": "Study tomes to unlock powerful upgrades.",
+                "icon": "icons/library.png",
+                "baseCost": 200
+        }
 ]

--- a/src/data/research.json
+++ b/src/data/research.json
@@ -1,0 +1,23 @@
+[
+    {
+        "id": "xp_boost_1",
+        "name": "Basic Monster Lore",
+        "description": "Monsters yield 10% more experience.",
+        "icon": "icons/book1.png",
+        "baseTime": 600
+    },
+    {
+        "id": "resource_boost_1",
+        "name": "Efficient Gathering",
+        "description": "Prestiging grants 2% more permanent resources.",
+        "icon": "icons/book2.png",
+        "baseTime": 900
+    },
+    {
+        "id": "library_speed",
+        "name": "Improved Scribes",
+        "description": "Research speed increased by 10%.",
+        "icon": "icons/book3.png",
+        "baseTime": 1200
+    }
+]

--- a/src/features/settlement/LibraryManager.ts
+++ b/src/features/settlement/LibraryManager.ts
@@ -1,0 +1,57 @@
+import { bus } from "@/core/EventBus";
+import { ResearchSpec } from "@/shared/types";
+import { ResearchUpgrade } from "./ResearchUpgrade";
+
+export class LibraryManager {
+    private researchMap = new Map<string, ResearchUpgrade>();
+    private activeResearch: ResearchUpgrade[] = [];
+    private completedResearch = new Set<string>();
+    private slots = 1;
+    private speedMultiplier = 1;
+
+    constructor() {
+        bus.on("Game:GameTick", (dt) => this.handleTick(dt));
+    }
+
+    registerResearch(specs: ResearchSpec[]) {
+        ResearchUpgrade.registerSpecs(specs);
+        specs.forEach((s) => {
+            const upgrade = ResearchUpgrade.create(s.id);
+            this.researchMap.set(s.id, upgrade);
+        });
+    }
+
+    startResearch(id: string) {
+        const upgrade = this.researchMap.get(id);
+        if (!upgrade || upgrade.unlocked) return;
+        if (this.activeResearch.length >= this.slots) return;
+        if (this.activeResearch.includes(upgrade)) return;
+        this.activeResearch.push(upgrade);
+        bus.emit("library:changed");
+    }
+
+    private handleTick(dt: number) {
+        for (const upg of this.activeResearch) {
+            upg.tick(dt, this.speedMultiplier);
+            if (upg.unlocked) {
+                this.completedResearch.add(upg.id);
+            }
+        }
+        this.activeResearch = this.activeResearch.filter((u) => !u.unlocked);
+        if (this.activeResearch.length > 0) bus.emit("library:changed");
+    }
+
+    getActive() {
+        return this.activeResearch;
+    }
+
+    getAvailable() {
+        return [...this.researchMap.values()].filter(
+            (u) => !u.unlocked && !this.activeResearch.includes(u)
+        );
+    }
+
+    getCompleted() {
+        return [...this.completedResearch];
+    }
+}

--- a/src/features/settlement/ResearchUpgrade.ts
+++ b/src/features/settlement/ResearchUpgrade.ts
@@ -1,0 +1,57 @@
+import { ResearchSpec, ResearchState } from "@/shared/types";
+import { SpecRegistryBase } from "@/models/SpecRegistryBase";
+
+export class ResearchUpgrade extends SpecRegistryBase<ResearchSpec> {
+    private constructor(private readonly spec: ResearchSpec, private state: ResearchState) {
+        super();
+    }
+
+    tick(dt: number, speed: number) {
+        if (this.state.unlocked) return;
+        this.state.progress += dt * speed;
+        if (this.state.progress >= this.spec.baseTime) {
+            this.state.unlocked = true;
+        }
+    }
+
+    get id() {
+        return this.spec.id;
+    }
+    get name() {
+        return this.spec.name;
+    }
+    get description() {
+        return this.spec.description;
+    }
+    get icon() {
+        return this.spec.icon;
+    }
+    get progress() {
+        return this.state.progress;
+    }
+    get requiredTime() {
+        return this.spec.baseTime;
+    }
+    get unlocked() {
+        return this.state.unlocked;
+    }
+
+    toJSON() {
+        return { __type: "ResearchUpgrade", spec: this.spec.id, state: this.state };
+    }
+
+    static fromJSON(raw: any) {
+        const spec = this.specById.get(raw.spec);
+        if (!spec) throw new Error(`Unknown research ${raw.spec}`);
+        return new ResearchUpgrade(spec, raw.state);
+    }
+
+    public static override specById = new Map<string, ResearchSpec>();
+
+    static create(id: string): ResearchUpgrade {
+        const spec = this.specById.get(id);
+        if (!spec) throw new Error(`Unknown research ${id}`);
+        const defaultState: ResearchState = { progress: 0, unlocked: false };
+        return new ResearchUpgrade(spec, defaultState);
+    }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -40,6 +40,19 @@ export interface BuildingSnapshot {
     nextUnlock: number;
 }
 
+export interface ResearchSpec {
+    id: string;
+    name: string;
+    description: string;
+    icon: string;
+    baseTime: number; // seconds required at base speed
+}
+
+export interface ResearchState {
+    progress: number;
+    unlocked: boolean;
+}
+
 // List as a readonly tuple
 export const CONSTRUCTION_RESOURCE_TYPES = ["stone", "metal"] as const;
 // Derive the union type automatically

--- a/src/ui/Screens/LibraryScreen.ts
+++ b/src/ui/Screens/LibraryScreen.ts
@@ -1,9 +1,85 @@
 import { BaseScreen } from "./BaseScreen";
+import Markup from "./library.html?raw";
+import { ProgressBar } from "../components/ProgressBar";
+import { bindEvent } from "@/shared/utils/busUtils";
+import { ResearchUpgrade } from "@/features/settlement/ResearchUpgrade";
 
 export class LibraryScreen extends BaseScreen {
-	readonly screenName = "library";
+    readonly screenName = "library";
+    private activeList!: HTMLElement;
+    private upgradeGrid!: HTMLElement;
+    private completedList!: HTMLElement;
 
-	init() {}
-	show() {}
-	hide() {}
+    init() {
+        this.addMarkuptoPage(Markup);
+        this.activeList = this.byId("libraryActiveList");
+        this.upgradeGrid = this.byId("libraryUpgradeGrid");
+        this.completedList = this.byId("libraryCompletedList");
+        this.build();
+        bindEvent(this.eventBindings, "library:changed", () => this.build());
+        bindEvent(this.eventBindings, "Game:UITick", () => this.updateActive());
+    }
+    show() {}
+    hide() {}
+
+    private build() {
+        this.updateActive();
+        this.updateAvailable();
+        this.updateCompleted();
+    }
+
+    private updateActive() {
+        const active = this.context.library.getActive();
+        this.activeList.innerHTML = "";
+        active.forEach((upg) => {
+            const row = document.createElement("div");
+            row.className = "library-research-row";
+            const icon = document.createElement("div");
+            icon.className = "library-research-icon";
+            icon.textContent = "📖";
+            row.appendChild(icon);
+            const info = document.createElement("div");
+            info.className = "library-research-info";
+            const title = document.createElement("span");
+            title.className = "library-research-title";
+            title.textContent = upg.name;
+            info.appendChild(title);
+            const progressContainer = document.createElement("div");
+            progressContainer.className = "library-research-progress";
+            info.appendChild(progressContainer);
+            new ProgressBar({
+                container: progressContainer,
+                maxValue: upg.requiredTime,
+                initialValue: upg.progress,
+            });
+            row.appendChild(info);
+            this.activeList.appendChild(row);
+        });
+    }
+
+    private updateAvailable() {
+        const avail = this.context.library.getAvailable();
+        this.upgradeGrid.innerHTML = "";
+        avail.forEach((upg) => {
+            const card = document.createElement("div");
+            card.className = "library-upgrade-card";
+            const name = document.createElement("div");
+            name.className = "library-upgrade-title";
+            name.textContent = upg.name;
+            card.appendChild(name);
+            card.addEventListener("click", () => this.context.library.startResearch(upg.id));
+            this.upgradeGrid.appendChild(card);
+        });
+    }
+
+    private updateCompleted() {
+        const list = this.context.library.getCompleted();
+        this.completedList.innerHTML = "";
+        list.forEach((id) => {
+            const spec = ResearchUpgrade.getSpec(id);
+            const li = document.createElement("li");
+            li.textContent = spec ? spec.name : id;
+            this.completedList.appendChild(li);
+        });
+    }
 }

--- a/src/ui/Screens/library.html
+++ b/src/ui/Screens/library.html
@@ -1,0 +1,12 @@
+<div class="library-page">
+    <div class="library-left">
+        <div class="library-section-header">Current Research</div>
+        <div class="library-active-list" id="libraryActiveList"></div>
+        <div class="library-section-header">Available Research</div>
+        <div class="library-upgrade-grid" id="libraryUpgradeGrid"></div>
+    </div>
+    <div class="library-right">
+        <div class="library-completed-header">Completed</div>
+        <ul class="library-completed-list" id="libraryCompletedList"></ul>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add library building info with icon
- create library research specs and registration
- implement `ResearchUpgrade` model and `LibraryManager`
- load library research data via `GameServices`
- expose library manager from `GameContext`
- add library screen markup and styles
- implement basic library UI

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68456faea580833092dd21d58743616c