### PR TITLE
Update building UI and build points

### DIFF
--- a/css/UIComponents.css
+++ b/css/UIComponents.css
@@ -538,3 +538,14 @@ section + section {
 .upgrade-action-btn {
         min-width: 70px;
 }
+
+/* Building Status */
+.building-status {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 0.5rem 1rem;
+        background: rgba(255, 255, 255, 0.1);
+        border-radius: 12px;
+        margin-bottom: 1rem;
+}

--- a/css/settlement.css
+++ b/css/settlement.css
@@ -25,8 +25,13 @@
 	letter-spacing: 0.05em;
 }
 .settlement-name {
-	font-weight: 700;
-	font-size: 1.2rem;
+        font-weight: 700;
+        font-size: 1.2rem;
+}
+#settlement-build-points {
+        font-weight: 700;
+        font-size: 1.2rem;
+        color: #5ff1ac;
 }
 
 .settlement-main {
@@ -36,31 +41,34 @@
 }
 
 .building-grid {
-	flex: 1;
-	display: grid;
-	grid-template-columns: repeat(3, 180px);
-	gap: 10px;
-	align-content: start;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
 }
-.building-card {
-	background: rgba(73, 116, 98, 0.555);
-	backdrop-filter: blur(7px);
-	border-radius: 8px;
-	box-shadow: 0 2px 12px rgba(0, 0, 0, 0.14);
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	padding: 18px 10px 14px 10px;
-	min-height: 148px;
-	position: relative;
-	color: #a7e3ff;
+.building-row {
+        background: rgba(73, 116, 98, 0.555);
+        backdrop-filter: blur(7px);
+        border-radius: 8px;
+        box-shadow: 0 2px 12px rgba(0, 0, 0, 0.14);
+        display: flex;
+        align-items: center;
+        padding: 10px;
+        color: #a7e3ff;
 }
-.building-contents {
-	width: 100%;
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	position: relative;
+.building-icon {
+        width: 48px;
+        height: 48px;
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-position: center;
+}
+.building-info {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        margin-left: 10px;
 }
 
 .plot-card {
@@ -76,57 +84,35 @@
 	position: relative;
 	color: #a7e3ff;
 }
-.building-card .building-title {
-	font-weight: 700;
-	font-size: 1.08rem;
-	margin: 10px 0 3px 0;
+.building-row .building-title {
+        font-weight: 700;
+        font-size: 1.08rem;
+        margin: 10px 0 3px 0;
 }
 
-.building-card .building-info {
-	font-weight: 300;
-	font-size: 0.7rem;
-	margin: 10px 0 3px 0;
-	color: #a7e3ff;
+.building-info .building-header {
+        font-weight: 300;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
 }
 
-.building-card .building-level {
-	font-size: 0.95rem;
-	color: #657799;
-	margin-bottom: 6px;
+.building-row .building-level {
+        font-size: 0.95rem;
+        color: #657799;
 }
-.spend-points-btn {
-	display: flex;
-	margin-top: auto;
-	align-self: self-end;
-	margin: 8px;
-	padding: 4px 8px;
-	background: #487a5b;
-	border: none;
-	border-radius: 8px;
-	color: #dbe7ff;
+.spend-btn {
+        display: flex;
+        margin-right: 6px;
+        padding: 4px 8px;
+        background: #487a5b;
+        border: none;
+        border-radius: 8px;
+        color: #dbe7ff;
 	font-weight: 600;
 	cursor: pointer;
-	font-size: 0.95rem;
-	transition: background 0.18s;
-}
-
-.upgrade-btn,
-.build-btn {
-	margin-top: auto;
-	padding: 5px 18px;
-	background: #7f95aa;
-	border: none;
-	border-radius: 8px;
-	color: #c9dbff;
-	font-weight: 600;
-	cursor: pointer;
-	font-size: 0.95rem;
-	transition: background 0.18s;
-}
-.upgrade-btn:hover,
-.build-btn:hover {
-	background: #5d97e0;
-	color: #fff;
+        font-size: 0.95rem;
+        transition: background 0.18s;
 }
 .add-plot .building-icon {
 	color: #7cae86;

--- a/src/balance/GameBalance.ts
+++ b/src/balance/GameBalance.ts
@@ -326,9 +326,11 @@ export const BalanceCalculators = {
 	/**
 	 * Calculate building upgrade cost
 	 */
-	getBuildingCost(baseCost: number, currentLevel: number): number {
-		return Math.floor(baseCost * Math.pow(GAME_BALANCE.buildings.costMultiplier, currentLevel));
-	},
+        getBuildingCost(baseCost: number, currentLevel: number): number {
+                // Each level requires 10x more build points than the base cost
+                // e.g. Level 1 -> 10 * baseCost, Level 2 -> 20 * baseCost
+                return Math.floor(baseCost * currentLevel * 10);
+        },
 
 	// === COMBAT CALCULATIONS ===
 

--- a/src/features/settlement/Building.ts
+++ b/src/features/settlement/Building.ts
@@ -21,17 +21,21 @@ export class Building extends SpecRegistryBase<BuildingSpec> {
 	public spendPoints(amt: number) {
 		this.state.pointsAllocated += amt;
 		// loop in case there's enough for multiple levels
-		while (this.state.pointsAllocated >= this.state.nextUnlock) {
-			this.state.pointsAllocated -= this.state.nextUnlock;
-			this.upgradeBuilding();
-			this.state.nextUnlock = BalanceCalculators.getBuildingCost(this.spec.baseCost, this.level);
-			// TODO - Check this is the best way compared to just multiplying based on the last unlock. This method provides balancing in future updates, but harder to work with.
-		}
-	}
+                while (this.state.pointsAllocated >= this.state.nextUnlock) {
+                        this.state.pointsAllocated -= this.state.nextUnlock;
+                        this.upgradeBuilding();
+                        // Cost for the next level scales with (level + 1)
+                        this.state.nextUnlock = BalanceCalculators.getBuildingCost(
+                                this.spec.baseCost,
+                                this.level + 1
+                        );
+                        // TODO - Check this is the best way compared to just multiplying based on the last unlock. This method provides balancing in future updates, but harder to work with.
+                }
+        }
 
-	public getUnlockCostData() {
-		return { cost: this.spec.baseCost, spent: this.state.pointsAllocated };
-	}
+        public getUnlockCostData() {
+                return { cost: this.state.nextUnlock, spent: this.state.pointsAllocated };
+        }
 
 	get id() {
 		return this.spec.id;
@@ -98,7 +102,7 @@ export class Building extends SpecRegistryBase<BuildingSpec> {
 			unlockStatus: "hidden",
 			pointsAllocated: 0,
 			level: 0,
-			nextUnlock: spec.baseCost,
+                        nextUnlock: BalanceCalculators.getBuildingCost(spec.baseCost, 1),
 		};
 		return new Building(spec, defaultState);
 	}

--- a/src/features/settlement/SettlementManager.ts
+++ b/src/features/settlement/SettlementManager.ts
@@ -232,12 +232,18 @@ export class SettlementManager extends GameBase implements Saveable {
 		bus.emit("settlement:changed");
 	}
 
-	spendUnlockPoints(type: BuildingType, amt: number) {
-		const building = this.buildingsMap.get(type);
-		if (!building) return;
-		building.spendPoints(10);
-		bus.emit("settlement:changed");
-	}
+        spendBuildPoints(type: BuildingType, amt: number) {
+                const building = this.buildingsMap.get(type);
+                if (!building) return;
+
+                const spend = Math.min(amt, this.settlementBuildPoints);
+                if (spend <= 0) return;
+
+                this.settlementBuildPoints -= spend;
+                building.spendPoints(spend);
+                bus.emit("settlement:buildPointsChanged", this.settlementBuildPoints);
+                bus.emit("settlement:changed");
+        }
 
 	// GETTERS AND SETTERS
 

--- a/src/ui/Screens/BlacksmithScreen.ts
+++ b/src/ui/Screens/BlacksmithScreen.ts
@@ -6,6 +6,7 @@ import { Resource } from "@/features/inventory/Resource";
 import { Tooltip } from "../components/Tooltip";
 import { BlacksmithSlot } from "../components/BlacksmithSlot";
 import { UpgradeSelectionContainer, UpgradeSelectionData } from "../components/UpgradeSelectionContainer";
+import { BuildingStatus } from "../components/BuildingStatus";
 
 interface ResourceRowData {
 	element: HTMLElement;
@@ -36,11 +37,14 @@ export class BlacksmithScreen extends BaseScreen {
         // Upgrade selection component
         private upgradeContainer!: UpgradeSelectionContainer;
 
-	init() {
-		this.addMarkuptoPage(Markup);
-		this.slotGrid = this.byId("bsSlotGrid");
-		this.resourceList = this.byId("bsResourceList");
-		this.upgradeGrid = this.byId("bsUpgradeGrid");
+        init() {
+                const root = this.addMarkuptoPage(Markup);
+                const statusEl = root.querySelector("#bs-building-status") as HTMLElement;
+                const building = this.context.settlement.getBuilding("blacksmith");
+                if (building && statusEl) new BuildingStatus(statusEl, building);
+                this.slotGrid = this.byId("bsSlotGrid");
+                this.resourceList = this.byId("bsResourceList");
+                this.upgradeGrid = this.byId("bsUpgradeGrid");
 
 		this.buildInitial();
 		this.bindEvents();

--- a/src/ui/Screens/GuildHallScreen.ts
+++ b/src/ui/Screens/GuildHallScreen.ts
@@ -3,6 +3,7 @@ import Markup from "./guildhall.html?raw";
 import { bindEvent } from "@/shared/utils/busUtils";
 import { BalanceCalculators } from "@/balance/GameBalance";
 import { formatTimeFull } from "@/shared/utils/stringUtils";
+import { BuildingStatus } from "../components/BuildingStatus";
 
 interface ChallengeSpec {
 	id: string;
@@ -42,9 +43,12 @@ export class GuildHallScreen extends BaseScreen {
 	private challengeLevels = new Map<string, number>();
 	private activeChallenge: string | null = null;
 
-	init() {
-		const root = this.addMarkuptoPage(Markup);
-		this.runTimeEl = root.querySelector("#gh-run-time") as HTMLElement;
+        init() {
+                const root = this.addMarkuptoPage(Markup);
+                const statusEl = root.querySelector("#gh-building-status") as HTMLElement;
+                const building = this.context.settlement.getBuilding("guild_hall");
+                if (building && statusEl) new BuildingStatus(statusEl, building);
+                this.runTimeEl = root.querySelector("#gh-run-time") as HTMLElement;
 		this.levelEl = root.querySelector("#gh-level") as HTMLElement;
 		this.areaEl = root.querySelector("#gh-area") as HTMLElement;
 		this.killsEl = root.querySelector("#gh-kills") as HTMLElement;

--- a/src/ui/Screens/LibraryScreen.ts
+++ b/src/ui/Screens/LibraryScreen.ts
@@ -4,6 +4,7 @@ import { ProgressBar } from "../components/ProgressBar";
 import { bindEvent } from "@/shared/utils/busUtils";
 import { ResearchUpgrade } from "@/features/settlement/ResearchUpgrade";
 import { UpgradeSelectionContainer, UpgradeSelectionData } from "../components/UpgradeSelectionContainer";
+import { BuildingStatus } from "../components/BuildingStatus";
 
 export class LibraryScreen extends BaseScreen {
 	readonly screenName = "library";
@@ -12,9 +13,12 @@ export class LibraryScreen extends BaseScreen {
 	private completedList!: HTMLElement;
 	private upgradeContainer!: UpgradeSelectionContainer;
 
-	init() {
-		this.addMarkuptoPage(Markup);
-		this.activeList = this.byId("libraryActiveList");
+        init() {
+                const root = this.addMarkuptoPage(Markup);
+                const statusEl = root.querySelector("#library-building-status") as HTMLElement;
+                const building = this.context.settlement.getBuilding("library");
+                if (building && statusEl) new BuildingStatus(statusEl, building);
+                this.activeList = this.byId("libraryActiveList");
 		this.upgradeGrid = this.byId("libraryUpgradeGrid");
 		this.completedList = this.byId("libraryCompletedList");
 		this.build();

--- a/src/ui/Screens/MineScreen.ts
+++ b/src/ui/Screens/MineScreen.ts
@@ -2,17 +2,21 @@ import { BaseScreen } from "./BaseScreen";
 import Markup from "./mine.html?raw";
 import { bus } from "@/core/EventBus";
 import { MineShaft } from "../components/MineShaft";
+import { BuildingStatus } from "../components/BuildingStatus";
 
 export class MineScreen extends BaseScreen {
 	readonly screenName = "mine";
 	private shafts: MineShaft[] = [];
 	private logEl!: HTMLElement;
 
-	init() {
-		this.addMarkuptoPage(Markup);
-		this.build();
-		bus.on("Game:UITick", () => this.update());
-		bus.on("settlement:changed", () => this.syncShafts());
+        init() {
+                const root = this.addMarkuptoPage(Markup);
+                const statusEl = root.querySelector("#mine-building-status") as HTMLElement;
+                const building = this.context.settlement.getBuilding("mine");
+                if (building && statusEl) new BuildingStatus(statusEl, building);
+                this.build();
+                bus.on("Game:UITick", () => this.update());
+                bus.on("settlement:changed", () => this.syncShafts());
 	}
 
 	show() {}

--- a/src/ui/Screens/blacksmith.html
+++ b/src/ui/Screens/blacksmith.html
@@ -1,4 +1,5 @@
 <div class="blacksmith-page">
+    <div id="bs-building-status"></div>
     <div class="blacksmith-main">
         <div class="blacksmith-slot-grid" id="bsSlotGrid"></div>
         <div class="blacksmith-upgrade-section">

--- a/src/ui/Screens/guildhall.html
+++ b/src/ui/Screens/guildhall.html
@@ -1,4 +1,5 @@
 <section class="game guildhall-screen">
+  <div id="gh-building-status"></div>
   <div class="guildhall-section guildhall-summary">
     <h2>Run Overview</h2>
     <ul class="run-stats">

--- a/src/ui/Screens/library.html
+++ b/src/ui/Screens/library.html
@@ -1,4 +1,5 @@
 <div class="library-page">
+    <div id="library-building-status"></div>
     <div class="library-left">
         <div class="library-section-header">Current Research</div>
         <div class="library-active-list" id="libraryActiveList"></div>

--- a/src/ui/Screens/mine.html
+++ b/src/ui/Screens/mine.html
@@ -1,4 +1,5 @@
 <div class="mine-page">
+    <div id="mine-building-status"></div>
     <div class="mine-section-header">Mine Resources</div>
     <div class="mine-resource-list" id="mineResourceList"></div>
     <div class="mine-output" id="mineOutput"></div>

--- a/src/ui/Screens/settlement.html
+++ b/src/ui/Screens/settlement.html
@@ -1,12 +1,14 @@
 <section class="game settlement-screen">
     <template id="building-card">
-        <div class="building-card">
-            <div class="building-icon library"></div>
-            <div class="building-title">Library</div>
-            <div class="building-contents">
-                test
-                <div class="building-level">Lv 2</div>
-                <button class="upgrade-btn">Upgrade</button>
+        <div class="building-row">
+            <div class="building-icon"></div>
+            <div class="building-info">
+                <div class="building-header">
+                    <span class="building-title"></span>
+                    <span class="building-level"></span>
+                </div>
+                <div class="progress-holder"></div>
+                <div class="spend-points"></div>
             </div>
         </div>
     </template>

--- a/src/ui/components/BuildingStatus.ts
+++ b/src/ui/components/BuildingStatus.ts
@@ -1,0 +1,35 @@
+import { Building } from "@/features/settlement/Building";
+import { UIBase } from "./UIBase";
+import { bus } from "@/core/EventBus";
+
+export class BuildingStatus extends UIBase {
+    private levelEl!: HTMLElement;
+    private allocatedEl!: HTMLElement;
+    private requiredEl!: HTMLElement;
+    constructor(private container: HTMLElement, private building: Building) {
+        super();
+        const root = document.createElement("div");
+        root.classList.add("building-status");
+        this.element = root;
+
+        const nameEl = document.createElement("span");
+        nameEl.textContent = building.displayName;
+        nameEl.classList.add("bs-name");
+
+        this.levelEl = document.createElement("span");
+        this.allocatedEl = document.createElement("span");
+        this.requiredEl = document.createElement("span");
+        root.append(nameEl, this.levelEl, this.allocatedEl, this.requiredEl);
+        this.container.appendChild(root);
+
+        this.update();
+        bus.on("settlement:changed", () => this.update());
+    }
+
+    private update() {
+        const snap = this.building.snapshot;
+        this.levelEl.textContent = `Lv ${snap.level}`;
+        this.allocatedEl.textContent = `Allocated: ${snap.pointsAllocated}`;
+        this.requiredEl.textContent = `Next: ${snap.nextUnlock}`;
+    }
+}


### PR DESCRIPTION
## Summary
- show build points more prominently and switch to linear cost formula
- rework settlement building list to vertical rows with progress bars
- allow spending build points in various amounts
- add BuildingStatus component and display it on building screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68527a2195e08330bd14805609b0c739