### PR TITLE
Improve building display UI

### DIFF
--- a/css/settlement.css
+++ b/css/settlement.css
@@ -93,13 +93,36 @@
 .building-info .building-header {
         font-weight: 300;
         display: flex;
-        justify-content: space-between;
         align-items: center;
+        gap: 6px;
 }
 
 .building-row .building-level {
-        font-size: 0.95rem;
-        color: #657799;
+        font-size: 0.85rem;
+        color: #e7eaf1;
+        background: #333;
+        padding: 2px 6px;
+        border-radius: 6px;
+}
+
+.progress-holder {
+        position: relative;
+}
+
+.progress-holder .progress-text {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        font-size: 0.75rem;
+        color: #fff;
+        pointer-events: none;
+}
+
+.spend-points {
+        display: flex;
+        gap: 6px;
+        margin-top: 4px;
 }
 .spend-btn {
         display: flex;

--- a/src/ui/Screens/settlement.html
+++ b/src/ui/Screens/settlement.html
@@ -4,10 +4,12 @@
             <div class="building-icon"></div>
             <div class="building-info">
                 <div class="building-header">
-                    <span class="building-title"></span>
                     <span class="building-level"></span>
+                    <span class="building-title"></span>
                 </div>
-                <div class="progress-holder"></div>
+                <div class="progress-holder">
+                    <div class="progress-text"></div>
+                </div>
                 <div class="spend-points"></div>
             </div>
         </div>

--- a/src/ui/components/BuildingDisplay.ts
+++ b/src/ui/components/BuildingDisplay.ts
@@ -8,6 +8,7 @@ export class BuildingDisplay extends UIBase {
     private levelEl!: HTMLElement;
     private progress!: ProgressBar;
     private spendContainer!: HTMLElement;
+    private progressText!: HTMLElement;
 
     constructor(private containerEl: HTMLElement, template: HTMLTemplateElement, private building: Building) {
         super();
@@ -26,6 +27,7 @@ export class BuildingDisplay extends UIBase {
         this.levelEl = root.querySelector(".building-level") as HTMLElement;
         this.spendContainer = root.querySelector(".spend-points") as HTMLElement;
         const progressHolder = root.querySelector(".progress-holder") as HTMLElement;
+        this.progressText = progressHolder.querySelector(".progress-text") as HTMLElement;
 
         this.progress = new ProgressBar({ container: progressHolder, templateId: undefined, initialValue: 0, maxValue: 1 });
 
@@ -82,6 +84,7 @@ export class BuildingDisplay extends UIBase {
         this.levelEl.textContent = `Lv ${snap.level}`;
         this.progress.setMax(snap.nextUnlock);
         this.progress.setValue(snap.pointsAllocated);
+        this.progressText.textContent = `${snap.pointsAllocated} / ${snap.nextUnlock}`;
     }
 
     private handleMouseEnter() {


### PR DESCRIPTION
## Summary
- reorder settlement building header to show level first
- show progress text in building progress bar
- add progress text handling in `BuildingDisplay`
- tweak settlement CSS for new layout and horizontal build buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68529df819288330a531ff3cdff58d59