### PR TITLE
Refactor to plain numbers and add formatting helper

### DIFF
--- a/src/core/EventBus.ts
+++ b/src/core/EventBus.ts
@@ -5,7 +5,6 @@ import { PlayerCharacter } from "../models/PlayerCharacter";
 import { EnemyCharacter } from "../models/EnemyCharacter";
 import { poolChangedPayload } from "../models/value-objects/RegenPool";
 import { InventoryItemSpec } from "../shared/types";
-import { BigNumber } from "@/models/utils/BigNumber";
 import { AreaStats, EnemyStats, GameStats, PrestigeStats, UserStats } from "@/shared/stats-types";
 import { MilestoneEventPayload } from "@/shared/Milestones";
 import { GameRun, RunStats } from "./GameRun";
@@ -25,8 +24,8 @@ export interface GameEvents {
 	"game:systemsResumed": void;
 
 	"ui:screenChanged": string;
-	"renown:changed": BigNumber;
-	"renown:award": BigNumber;
+        "renown:changed": number;
+        "renown:award": number;
 
 	// RESOURCES
 	"resources:changed": Resource;
@@ -53,7 +52,7 @@ export interface GameEvents {
 
 	// PLAYER CHARACTER
 	"char:levelUp": number; // New Level
-	"char:gainedXp": BigNumber; // Amount incoming
+        "char:gainedXp": number; // Amount incoming
 
 	//HUNT
 	"hunt:stateChanged": HuntState;

--- a/src/core/StatsEngine.ts
+++ b/src/core/StatsEngine.ts
@@ -1,6 +1,5 @@
 import { StatsModifier, CoreStats, Stats, defaultPlayerStats } from "@/models/Stats";
 import { bus } from "./EventBus";
-import { BigNumber } from "@/models/utils/BigNumber";
 import { mergeStats } from "@/shared/utils/stat-utils";
 
 export type LayerFn = () => StatsModifier;
@@ -29,9 +28,9 @@ export class StatsEngine {
 		this.recalculate();
 	}
 
-	get<K extends keyof Stats>(key: K): Stats[K] {
-		return this.current[key] ?? new BigNumber(0);
-	}
+        get<K extends keyof Stats>(key: K): Stats[K] {
+                return this.current[key] ?? 0;
+        }
 
 	getAll(): Stats {
 		return { ...this.current };

--- a/src/features/hunt/CombatManager.ts
+++ b/src/features/hunt/CombatManager.ts
@@ -8,7 +8,6 @@ import { Area } from "@/models/Area";
 import { EffectProcessor } from "./EffectProcessor";
 import { Destroyable } from "@/core/Destroyable";
 import { GameContext } from "@/core/GameContext";
-import { BigNumber } from "@/models/utils/BigNumber";
 
 export class CombatManager extends Destroyable {
     private effectProcessor: EffectProcessor;
@@ -94,7 +93,7 @@ export class CombatManager extends Destroyable {
         this.context.player.adjustRenown(renownReward);
 
         // Award experience
-        this.context.character.gainXp(new BigNumber(this.area.getXpPerKill(false)));
+        this.context.character.gainXp(this.area.getXpPerKill(false));
 
         //this.context.player.gainExperience(expReward);
 

--- a/src/models/OfflineProgress.ts
+++ b/src/models/OfflineProgress.ts
@@ -10,7 +10,6 @@
 
 import { GameContext } from "@/core/GameContext";
 import { OfflineProgressModal } from "@/ui/components/OfflineProgressModal";
-import { BigNumber } from "./utils/BigNumber";
 import { Area } from "./Area";
 import { PlayerCharacter } from "./PlayerCharacter";
 import { printLog } from "@/core/DebugManager";
@@ -52,9 +51,9 @@ export interface OfflineProgressHandler {
  * Only hunt system returns detailed info - everything else returns null
  */
 export interface OfflineProgressInfo {
-	enemiesKilled: number;
-	renownGained: BigNumber;
-	experienceGained: BigNumber;
+        enemiesKilled: number;
+        renownGained: number;
+        experienceGained: number;
 	treasureChests: number;
 	treasureBreakdown: Array<{ interval: string; chestsFromInterval: number }>;
 	nextChestIn: number;
@@ -288,8 +287,8 @@ class HuntOfflineHandler implements OfflineProgressHandler {
 		if (!area) {
 			return {
 				enemiesKilled: 0,
-				renownGained: new BigNumber(0),
-				experienceGained: new BigNumber(0),
+                                renownGained: 0,
+                                experienceGained: 0,
 				treasureChests: 0,
 				treasureBreakdown: [],
 				nextChestIn: 30 * 60,
@@ -305,11 +304,11 @@ class HuntOfflineHandler implements OfflineProgressHandler {
 		const kills = Math.floor((offlineSeconds / avgKillTime) * efficiency);
 
 		// Apply the rewards directly here since we're calculating them
-		const renownGained = new BigNumber(kills * area.tier);
-		const xpGained = new BigNumber(kills).multiply(area.getXpPerKill(false));
+                const renownGained = kills * area.tier;
+                const xpGained = kills * area.getXpPerKill(false);
 
-		context.player.adjustRenown(renownGained);
-		context.character.gainXp(xpGained);
+                context.player.adjustRenown(renownGained);
+                context.character.gainXp(xpGained);
 
 		const chests = this.treasure.calculateTreasureRewards(offlineSeconds);
 		if (chests.chestsEarned > 0) {

--- a/src/models/value-objects/Bounded.ts
+++ b/src/models/value-objects/Bounded.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from "../utils/BigNumber";
 
 /* ─────────── BoundedNumber ─────────── */
 
@@ -60,73 +59,5 @@ export class BoundedNumber {
     }
     static fromJSON(raw: any): BoundedNumber {
         return new BoundedNumber(raw.min, raw.max, raw.current);
-    }
-}
-
-/* ─────────── BoundedBig ─────────── */
-
-export class BoundedBig {
-    private _current: BigNumber;
-
-    constructor(public max: BigNumber, current: BigNumber, public min: BigNumber = new BigNumber(0)) {
-        if (min.gt(max)) throw new Error("min cannot exceed max");
-        this._current = this.clamp(current);
-    }
-
-    /* ——— accessors ——— */
-    get current(): BigNumber {
-        return this._current;
-    }
-    set current(v: BigNumber) {
-        this._current = this.clamp(v);
-    }
-    get percent(): number {
-        return this.max.eq(0) ? 0 : this._current.div(this.max).toNumber();
-    }
-
-    /* ——— mutators ——— */
-    setToMax() {
-        this.current = this.max;
-    }
-    setToMin() {
-        this.current = this.min;
-    }
-    adjust(delta: BigNumber) {
-        this.current = this.current.add(delta).clampMinZero();
-    }
-    increase(amount: BigNumber) {
-        this.adjust(amount);
-    }
-    decrease(amount: BigNumber) {
-        this.adjust(amount.multiply(-1));
-    }
-
-    /* ——— queries ——— */
-    isEmpty(): boolean {
-        return this.current.lte(this.min);
-    }
-    isFull(): boolean {
-        return this.current.gte(this.max);
-    }
-    getRounded(): number {
-        return Math.floor(this.current.toNumber());
-    }
-
-    /* ——— helpers ——— */
-    private clamp(v: BigNumber): BigNumber {
-        return BigNumber.min(BigNumber.max(v, this.min), this.max);
-    }
-
-    /* ——— serialisation ——— */
-    toJSON() {
-        return {
-            __type: "BoundedBig",
-            min: this.min.toJSON(),
-            max: this.max.toJSON(),
-            current: this.current.toJSON(),
-        };
-    }
-    static fromJSON(raw: any): BoundedBig {
-        return new BoundedBig(BigNumber.fromJSON(raw.min), BigNumber.fromJSON(raw.max), BigNumber.fromJSON(raw.current));
     }
 }

--- a/src/shared/stats-types.ts
+++ b/src/shared/stats-types.ts
@@ -1,10 +1,9 @@
-import { BigNumber } from "@/models/utils/BigNumber";
 
 export interface UserStats {
     level: number;
     prestiges: number;
-    renownGained: BigNumber;
-    renownSpent: BigNumber;
+    renownGained: number;
+    renownSpent: number;
 }
 
 export interface AreaStats {
@@ -46,8 +45,8 @@ export interface GameStats {
 export const DEFAULT_USER_STATS: UserStats = {
     level: 1,
     prestiges: 0,
-    renownGained: new BigNumber(0),
-    renownSpent: new BigNumber(0),
+    renownGained: 0,
+    renownSpent: 0,
 };
 
 export const DEFAULT_ENEMY_STATS: EnemyStats = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -4,7 +4,6 @@ import { Stats, StatsModifier } from "@/models/Stats";
 import { MilestoneTag } from "./Milestones";
 import { GameEvents } from "@/core/EventBus";
 import { BaseCharacter } from "@/models/BaseCharacter";
-import { BigNumber } from "@/models/utils/BigNumber";
 
 // --------------------- SETTLEMENT + BUILDINGS ----------------------------
 export const STARTING_BUILDING_UNLOCKS = ["guildHall"];
@@ -134,8 +133,8 @@ export interface EffectInstance {
 	source: BaseCharacter;
 	target: "self" | "enemy";
 	type: EffectType;
-	/** raw amount (damage before mitigation, heal % of maxHp, buff %, etc.) */
-	rawValue: BigNumber;
+        /** raw amount (damage before mitigation, heal % of maxHp, buff %, etc.) */
+        rawValue: number;
 	durationSeconds?: number;
 	statKey?: keyof Stats;
 }
@@ -145,8 +144,8 @@ export interface EffectResult {
 	source: BaseCharacter;
 	target: BaseCharacter;
 	effect: EffectInstance;
-	/** e.g. finalDamage after mitigation, or actualHealAmount */
-	outcomeValue: BigNumber;
+        /** e.g. finalDamage after mitigation, or actualHealAmount */
+        outcomeValue: number;
 }
 
 // -------------------- ITEMS ------------------------------

--- a/src/shared/utils/stat-utils.ts
+++ b/src/shared/utils/stat-utils.ts
@@ -1,35 +1,7 @@
 import { Stats, StatsModifier } from "@/models/Stats";
-import { BigNumber } from "@/models/utils/BigNumber";
 import { ItemRarity } from "../types";
 import { BaseCharacter } from "@/models/BaseCharacter";
 import { RARITY_MULTIPLIERS } from "@/balance/GameBalance";
-
-// Convert any object of numbers to BigNumbers
-export function toBigNumberStats<T extends Record<string, number>>(raw: T): { [K in keyof T]: BigNumber } {
-	const out = {} as { [K in keyof T]: BigNumber };
-	for (const k in raw) {
-		out[k] = new BigNumber(raw[k]);
-	}
-	return out;
-}
-
-// Accepts mixed types, skips anything already a BigNumber
-export function toBigNumberModifier<T extends Record<string, number | BigNumber | undefined>>(raw: T): { [K in keyof T]: BigNumber } {
-	const out = {} as { [K in keyof T]: BigNumber };
-	for (const k in raw) {
-		const val = raw[k];
-		if (val instanceof BigNumber) {
-			out[k] = val;
-		} else if (typeof val === "number") {
-			out[k] = new BigNumber(val);
-		} else {
-			out[k] = new BigNumber(0); // default for undefined, or skip this line if you want sparse
-		}
-	}
-	return out;
-}
-
-// Assumes every field in a and b is a BigNumber or undefined
 export function mergeStatModifiers(a: StatsModifier, b: StatsModifier): StatsModifier {
 	const out: StatsModifier = { ...a };
 	for (const k in b) {
@@ -79,13 +51,12 @@ export function scaleStatsModifier(mod: StatsModifier, rarity: ItemRarity): Stat
 }
 
 /** Helper: roll crit/variance, apply power multipliers, etc. */
-export function calculateRawBaseDamage(char: BaseCharacter): BigNumber {
+export function calculateRawBaseDamage(char: BaseCharacter): number {
 	// LEVEL * ATTACK * POWER
 	//const level = char.level;
-	const attack = new BigNumber(char.stats.get("attack"));
-	const powerMultiplier = 1 + char.stats.get("power") / 100;
+        const attack = char.stats.get("attack");
+        const powerMultiplier = 1 + char.stats.get("power") / 100;
 
-	// for a damage effect: attack × power × crit × variance × effect.scale
-	const totalMultiplier = powerMultiplier;
-	return attack.multiply(totalMultiplier);
+        const totalMultiplier = powerMultiplier;
+        return attack * totalMultiplier;
 }

--- a/src/shared/utils/stringUtils.ts
+++ b/src/shared/utils/stringUtils.ts
@@ -20,6 +20,18 @@ export function formatTimeFull(ms: number): string {
 	totalSeconds %= 3600;
 	const minutes = Math.floor(totalSeconds / 60);
 	const seconds = totalSeconds % 60;
-	const pad = (n: number) => n.toString().padStart(2, "0");
-	return `${hours}:${pad(minutes)}:${pad(seconds)}`;
+        const pad = (n: number) => n.toString().padStart(2, "0");
+        return `${hours}:${pad(minutes)}:${pad(seconds)}`;
+}
+
+export function formatNumberShort(value: number): string {
+        const units = ["", "k", "m", "b", "t"];
+        let unitIndex = 0;
+        while (Math.abs(value) >= 1000 && unitIndex < units.length - 1) {
+                value /= 1000;
+                unitIndex++;
+        }
+        let str = value.toFixed(1);
+        if (str.endsWith(".0")) str = str.slice(0, -2);
+        return str + units[unitIndex];
 }

--- a/src/storage/reviver.ts
+++ b/src/storage/reviver.ts
@@ -1,9 +1,8 @@
 import { Equipment } from "@/models/Equipment";
 import { ClassCard } from "@/features/classcards/ClassCard";
 import { TrainedStat } from "@/models/TrainedStat";
-import { BoundedBig, BoundedNumber } from "@/models/value-objects/Bounded";
+import { BoundedNumber } from "@/models/value-objects/Bounded";
 import { RegenPool } from "@/models/value-objects/RegenPool";
-import { BigNumber } from "@/models/utils/BigNumber";
 import { Building } from "@/features/settlement/Building";
 
 /* export function reviveGame(_key: string, value: any) {
@@ -24,14 +23,10 @@ export function reviveGame(_key: string, value: any): any {
 				return TrainedStat.fromJSON(value);
 			case "BoundedNumber":
 				return BoundedNumber.fromJSON(value);
-			case "BoundedBig":
-				return BoundedBig.fromJSON(value);
-			case "RegenPool":
-				return RegenPool.fromJSON(value);
-			case "BigNumber":
-				return BigNumber.fromJSON(value);
-			case "Building":
-				return Building.fromJSON(value);
+                        case "RegenPool":
+                                return RegenPool.fromJSON(value);
+                        case "Building":
+                                return Building.fromJSON(value);
 
 			// …add cases for any other types…
 		}

--- a/src/ui/components/PlayerStatsDisplay.ts
+++ b/src/ui/components/PlayerStatsDisplay.ts
@@ -3,7 +3,6 @@ import { UIBase } from "./UIBase";
 import { bindEvent } from "@/shared/utils/busUtils";
 import { prettify } from "@/shared/utils/stringUtils";
 import { calculateRawBaseDamage } from "@/shared/utils/stat-utils";
-import { BigNumber } from "@/models/utils/BigNumber";
 import { ProgressBarSimple } from "./ProgressBarSimple";
 
 interface StatData {

--- a/src/ui/components/ProgressBarSimple.ts
+++ b/src/ui/components/ProgressBarSimple.ts
@@ -1,21 +1,20 @@
 // progressBar.ts
-import { BigNumber } from "@/models/utils/BigNumber";
 import { UIBase } from "./UIBase";
 
 export interface ProgressBarOptions {
 	container: HTMLElement;
 	templateId?: string;
 	/** Starting "current" value; defaults to 0 */
-	initialValue?: number | BigNumber;
+        initialValue?: number;
 	/** Starting "max" value; defaults to 100 */
-	maxValue?: number | BigNumber;
+        maxValue?: number;
 }
 
 export class ProgressBarSimple extends UIBase {
 	private root: HTMLElement;
 	private fillEl: HTMLElement;
-	private current: BigNumber;
-	private max: BigNumber;
+        private current: number;
+        private max: number;
 
 	constructor(options: ProgressBarOptions) {
 		super();
@@ -26,18 +25,13 @@ export class ProgressBarSimple extends UIBase {
 		this.fillEl = this.root.querySelector(".mh-progress__fill")!;
 		this.fillEl.classList.add("mh-progress--generic");
 
-		// Convert everything to BigNumber at construction time
-		this.max = this.toBigNumber(options.maxValue ?? 100);
-		this.current = this.toBigNumber(options.initialValue ?? 0);
+                this.max = options.maxValue ?? 100;
+                this.current = options.initialValue ?? 0;
 
 		// Render initial state
 		this.updateFill();
 	}
 
-	/** Helper to convert number | BigNumber to BigNumber */
-	private toBigNumber(value: number | BigNumber): BigNumber {
-		return value instanceof BigNumber ? value : new BigNumber(value);
-	}
 
 	/** Clones the <template> and appends it to the container */
 	private cloneTemplate(templateId: string, container: HTMLElement): HTMLElement {
@@ -48,51 +42,49 @@ export class ProgressBarSimple extends UIBase {
 	}
 
 	/** Set a new "current" value (clamped 0–max) and redraws the fill */
-	public setValue(value: number | BigNumber): void {
-		const bigValue = this.toBigNumber(value);
-		// Clamp between 0 and max using BigNumber methods
-		const zero = new BigNumber(0);
-		this.current = BigNumber.min(BigNumber.max(bigValue, zero), this.max);
-		this.updateFill();
-	}
+        public setValue(value: number): void {
+                const clamped = Math.max(0, Math.min(value, this.max));
+                this.current = clamped;
+                this.updateFill();
+        }
 
 	/** Change the "max" value and re-apply the current fill */
-	public setMax(max: number | BigNumber): void {
-		this.max = this.toBigNumber(max);
-		this.setValue(this.current); // Re-clamp current value against new max
-	}
+        public setMax(max: number): void {
+                this.max = max;
+                this.setValue(this.current); // Re-clamp current value against new max
+        }
 
 	/** Computes percentage and writes it to the fill's width */
 	private updateFill(): void {
 		// Only convert to number at display time for percentage calculation
-		const pct = this.max.eq(0) ? 0 : this.current.div(this.max).toNumber() * 100;
-		this.fillEl.style.width = `${pct}%`;
-	}
+                const pct = this.max === 0 ? 0 : (this.current / this.max) * 100;
+                this.fillEl.style.width = `${pct}%`;
+        }
 
-	/** Get current value as BigNumber */
-	public getValue(): BigNumber {
-		return this.current;
-	}
+        /** Get current value */
+        public getValue(): number {
+                return this.current;
+        }
 
-	/** Get max value as BigNumber */
-	public getMax(): BigNumber {
-		return this.max;
-	}
+        /** Get max value */
+        public getMax(): number {
+                return this.max;
+        }
 
 	/** Get current percentage as number (0-100) */
-	public getPercentage(): number {
-		return this.max.eq(0) ? 0 : this.current.div(this.max).toNumber() * 100;
-	}
+        public getPercentage(): number {
+                return this.max === 0 ? 0 : (this.current / this.max) * 100;
+        }
 
 	/** Check if progress bar is full */
-	public isFull(): boolean {
-		return this.current.gte(this.max);
-	}
+        public isFull(): boolean {
+                return this.current >= this.max;
+        }
 
 	/** Check if progress bar is empty */
-	public isEmpty(): boolean {
-		return this.current.eq(0);
-	}
+        public isEmpty(): boolean {
+                return this.current === 0;
+        }
 
 	/** Clean up the DOM when you no longer need this bar */
 	public destroy(): void {


### PR DESCRIPTION
## Summary
- remove `BigNumber` usage across the project
- use plain numbers for all calculations and state
- simplify `ModifierEngine`, `BoundedNumber` and related classes
- add `formatNumberShort` helper for readable numbers
- update progress bar and other components to use numbers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853c091816c833087b1be888d61fb23