### PR TITLE
Implement class tree UI

### DIFF
--- a/css/character.css
+++ b/css/character.css
@@ -1,0 +1,105 @@
+/* Character screen class tree styles */
+.character-screen {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.class-points {
+  color: #fff;
+  padding: 0.5rem;
+  font-weight: 600;
+}
+
+.class-tree-wrapper {
+  flex: 1;
+  overflow: auto;
+  position: relative;
+  cursor: grab;
+}
+.class-tree-wrapper.dragging {
+  cursor: grabbing;
+}
+
+.class-tree {
+  position: relative;
+  min-height: 100%;
+}
+
+.class-column {
+  position: absolute;
+  top: 0;
+  min-height: 100%;
+  padding: 1rem 0.5rem;
+}
+
+.class-bg {
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.03);
+  pointer-events: none;
+}
+
+.class-lines {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.class-nodes {
+  position: relative;
+}
+
+.class-node {
+  position: absolute;
+  width: 48px;
+  height: 48px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 12px;
+}
+
+.class-node.locked {
+  filter: grayscale(1) opacity(0.5);
+}
+.class-node.partial {
+  border-color: #4aa3ff;
+}
+.class-node.maxed {
+  border-color: #30b060;
+}
+
+.node-cost,
+.node-level {
+  position: absolute;
+  font-size: 10px;
+  color: #fff;
+  pointer-events: none;
+}
+
+.node-cost {
+  left: -12px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.node-level {
+  right: -4px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.link-line {
+  stroke: rgba(255, 255, 255, 0.4);
+  stroke-width: 2;
+}
+.link-line.active {
+  stroke: #30b060;
+}

--- a/src/features/classes/ClassManager.ts
+++ b/src/features/classes/ClassManager.ts
@@ -35,6 +35,29 @@ export class ClassManager implements Saveable<ClassSystemState> {
     return this.availablePoints;
   }
 
+  /** Get all registered class specs */
+  getClassSpecs(): ClassSpec[] {
+    return Array.from(this.specs.values());
+  }
+
+  /** Points allocated to a specific node */
+  getNodePoints(classId: string, nodeId: string): number {
+    return this.nodePoints.get(classId)?.get(nodeId) ?? 0;
+  }
+
+  /** Total points spent across all classes */
+  getSpentPoints(): number {
+    let spent = 0;
+    for (const spec of this.specs.values()) {
+      const map = this.nodePoints.get(spec.id)!;
+      spec.nodes.forEach((n) => {
+        const pts = map.get(n.id) || 0;
+        spent += pts * n.cost;
+      });
+    }
+    return spent;
+  }
+
   allocatePoint(classId: string, nodeId: string): boolean {
     const classSpec = this.specs.get(classId);
     if (!classSpec) return false;

--- a/src/ui/Screens/CharacterScreen.ts
+++ b/src/ui/Screens/CharacterScreen.ts
@@ -1,27 +1,204 @@
-import { PlayerStatsDisplay } from "../components/PlayerStatsDisplay";
 import { BaseScreen } from "./BaseScreen";
 import Markup from "./character.html?raw";
 import { bus } from "@/core/EventBus";
+import { Tooltip } from "../components/Tooltip";
+import { ClassSpec, ClassNodeSpec } from "@/features/classes/ClassTypes";
 
 export class CharacterScreen extends BaseScreen {
-        readonly screenName = "character";
-        private playerStatsDiplay!: PlayerStatsDisplay;
-        private classTreeEl!: HTMLElement;
+    readonly screenName = "character";
 
-        init() {
-                this.addMarkuptoPage(Markup);
-                //this.element = this.getById("character-container")!;
-                //this.playerStatsDiplay = new PlayerStatsDisplay(this.byId("player-statlist")!);
-                this.classTreeEl = this.byId("class-tree")!;
-                this.updatePoints();
-                bus.on("classes:pointsChanged", () => this.updatePoints());
-        }
-        show() {}
-        hide() {}
-        bindEvents() {}
+    private pointsEl!: HTMLElement;
+    private scrollEl!: HTMLElement;
+    private treeEl!: HTMLElement;
+    private nodeMap = new Map<string, HTMLElement>();
+    private lineMap = new Map<string, SVGLineElement>();
 
-        private updatePoints() {
-                const pts = this.context.classes.getAvailablePoints();
-                this.classTreeEl.textContent = `Class Points: ${pts}`;
+    init() {
+        this.addMarkuptoPage(Markup);
+        this.pointsEl = this.byId("class-points");
+        this.scrollEl = this.byId("class-tree-scroll");
+        this.treeEl = this.byId("class-tree");
+        this.buildTree();
+        this.updatePoints();
+        bus.on("classes:pointsChanged", () => {
+            this.updatePoints();
+            this.updateNodeStates();
+            this.updateLines();
+        });
+        bus.on("classes:nodesChanged", () => {
+            this.updatePoints();
+            this.updateNodeStates();
+            this.updateLines();
+        });
+        this.setupDragScroll();
+    }
+    show() {}
+    hide() {}
+    bindEvents() {}
+
+    private updatePoints() {
+        const mgr = this.context.classes;
+        const available = mgr.getAvailablePoints();
+        const spent = mgr.getSpentPoints();
+        this.pointsEl.textContent = `Points: ${available} (spent ${spent})`;
+    }
+
+    private buildTree() {
+        const specs = this.context.classes.getClassSpecs();
+        this.treeEl.innerHTML = "";
+        this.nodeMap.clear();
+        this.lineMap.clear();
+
+        const NODE_SIZE = 48;
+        const COL_WIDTH = 280;
+        const ROW_HEIGHT = 90;
+        const COL_GAP = 40;
+
+        let colIndex = 0;
+        for (const spec of specs) {
+            const column = document.createElement("div");
+            column.className = "class-column";
+            column.style.left = `${colIndex * (COL_WIDTH + COL_GAP)}px`;
+            column.style.width = `${COL_WIDTH}px`;
+            column.dataset.classId = spec.id;
+
+            const bg = document.createElement("div");
+            bg.className = "class-bg";
+            column.appendChild(bg);
+
+            const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+            svg.classList.add("class-lines");
+            column.appendChild(svg);
+
+            const nodesContainer = document.createElement("div");
+            nodesContainer.className = "class-nodes";
+            column.appendChild(nodesContainer);
+
+            spec.nodes.forEach((n) => {
+                const el = this.createNodeElement(spec, n);
+                el.style.left = `${n.col * (NODE_SIZE + 40)}px`;
+                el.style.top = `${n.row * ROW_HEIGHT}px`;
+                nodesContainer.appendChild(el);
+                this.nodeMap.set(`${spec.id}:${n.id}`, el);
+            });
+
+            this.treeEl.appendChild(column);
+            colIndex++;
         }
+
+        // lines
+        for (const spec of specs) {
+            const svg = this.treeEl.querySelector<SVGSVGElement>(
+                `.class-column[data-class-id="${spec.id}"] .class-lines`
+            )!;
+            spec.nodes.forEach((n) => {
+                if (!n.prereq) return;
+                const fromEl = this.nodeMap.get(`${spec.id}:${n.prereq}`)!;
+                const toEl = this.nodeMap.get(`${spec.id}:${n.id}`)!;
+                const line = document.createElementNS("http://www.w3.org/2000/svg", "line");
+                const x1 = fromEl.offsetLeft + NODE_SIZE / 2;
+                const y1 = fromEl.offsetTop + NODE_SIZE;
+                const x2 = toEl.offsetLeft + NODE_SIZE / 2;
+                const y2 = toEl.offsetTop;
+                line.setAttribute("x1", `${x1}`);
+                line.setAttribute("y1", `${y1}`);
+                line.setAttribute("x2", `${x2}`);
+                line.setAttribute("y2", `${y2}`);
+                line.classList.add("link-line");
+                svg.appendChild(line);
+                this.lineMap.set(`${spec.id}:${n.id}`, line);
+            });
+        }
+
+        this.updateNodeStates();
+        this.updateLines();
+    }
+
+    private createNodeElement(spec: ClassSpec, node: ClassNodeSpec): HTMLElement {
+        const el = document.createElement("div");
+        el.className = "class-node";
+        el.dataset.classId = spec.id;
+        el.dataset.nodeId = node.id;
+        el.innerHTML = `
+            <span class="node-cost">${node.cost}</span>
+            <div class="node-icon"></div>
+            <span class="node-level">0/${node.maxPoints}</span>`;
+        el.addEventListener("click", () => this.handleNodeClick(spec.id, node.id));
+        el.addEventListener("mouseenter", () =>
+            Tooltip.instance.show(el, {
+                icon: "",
+                name: node.name,
+                description: "",
+            })
+        );
+        el.addEventListener("mouseleave", () => Tooltip.instance.hide());
+        return el;
+    }
+
+    private handleNodeClick(classId: string, nodeId: string) {
+        this.context.classes.allocatePoint(classId, nodeId);
+    }
+
+    private updateNodeStates() {
+        const mgr = this.context.classes;
+        for (const [key, el] of this.nodeMap) {
+            const [cid, nid] = key.split(":");
+            const spec = mgr.getClassSpecs().find((c) => c.id === cid)!;
+            const node = spec.nodes.find((n) => n.id === nid)!;
+            const pts = mgr.getNodePoints(cid, nid);
+            const levelEl = el.querySelector<HTMLElement>(".node-level")!;
+            levelEl.textContent = `${pts}/${node.maxPoints}`;
+
+            el.classList.toggle("maxed", pts >= node.maxPoints);
+            el.classList.toggle("partial", pts > 0 && pts < node.maxPoints);
+
+            const prereqMet = node.prereq ? mgr.getNodePoints(cid, node.prereq) > 0 : true;
+            const accessible = prereqMet && mgr.getAvailablePoints() >= node.cost;
+            el.classList.toggle("locked", !accessible && pts === 0);
+        }
+    }
+
+    private updateLines() {
+        const mgr = this.context.classes;
+        for (const [key, line] of this.lineMap) {
+            const [cid, nid] = key.split(":");
+            const node = mgr
+                .getClassSpecs()
+                .find((c) => c.id === cid)!
+                .nodes.find((n) => n.id === nid)!;
+            const fromPts = mgr.getNodePoints(cid, node.prereq!);
+            const toPts = mgr.getNodePoints(cid, nid);
+            line.classList.toggle("active", fromPts > 0 && toPts > 0);
+        }
+    }
+
+    private setupDragScroll() {
+        let isDown = false;
+        let startX = 0;
+        let startY = 0;
+        let scrollLeft = 0;
+        let scrollTop = 0;
+        const el = this.scrollEl;
+        el.addEventListener("mousedown", (e) => {
+            isDown = true;
+            startX = e.clientX;
+            startY = e.clientY;
+            scrollLeft = el.scrollLeft;
+            scrollTop = el.scrollTop;
+            el.classList.add("dragging");
+        });
+        window.addEventListener("mouseup", () => {
+            if (isDown) {
+                isDown = false;
+                el.classList.remove("dragging");
+            }
+        });
+        window.addEventListener("mousemove", (e) => {
+            if (!isDown) return;
+            const dx = e.clientX - startX;
+            const dy = e.clientY - startY;
+            el.scrollLeft = scrollLeft - dx;
+            el.scrollTop = scrollTop - dy;
+        });
+    }
 }

--- a/src/ui/Screens/character.html
+++ b/src/ui/Screens/character.html
@@ -1,9 +1,6 @@
 <section class="game character-screen" id="character-container">
-
-  <div class="player-statlist" id="player-statlist">
-
+  <div class="class-points" id="class-points"></div>
+  <div class="class-tree-wrapper" id="class-tree-scroll">
+    <div class="class-tree" id="class-tree"></div>
   </div>
-
-  <div id="class-tree"></div>
-
 </section>


### PR DESCRIPTION
## Summary
- render class trees on the character screen
- allow dragging/scrolling to navigate trees
- show available and spent points
- basic node tooltips and coloring
- expose data from `ClassManager` for UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855b629bfc483309834efcfacea7930