### PR TITLE
Improve character cards layout

### DIFF
--- a/css/hunt.css
+++ b/css/hunt.css
@@ -273,11 +273,17 @@
 }
 
 /* 1. Name */
+.char-card__header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+}
+
 .char-card__name {
-	font-size: 1.15rem;
-	font-weight: 600;
-	margin: 0;
-	letter-spacing: 0.03em;
+        font-size: 1.15rem;
+        font-weight: 600;
+        margin: 0;
+        letter-spacing: 0.03em;
 }
 
 .affinity-row {
@@ -319,9 +325,12 @@
 
 /* 2. Health + Portrait Row */
 .char-card__row {
-	display: flex;
-	gap: 1rem;
-	align-items: flex-start;
+        display: flex;
+        gap: 1rem;
+        align-items: flex-start;
+}
+.char-card.enemy .char-card__row {
+        flex-direction: row-reverse;
 }
 
 .char-card__portrait {
@@ -385,25 +394,44 @@
 
 /* 3. Ability List */
 .ability-list {
-	list-style: none;
-	margin: 0;
-	padding: 0;
-	display: flex;
-	flex-direction: column;
-	gap: 0.5rem;
+        list-style: none;
+        margin: 0;
+        padding: 0.4rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        background: rgba(34, 33, 33, 0.363);
+        border: 1px solid var(--hunt-card-border);
+        border-radius: 0.5rem;
+        flex: 1;
 }
 /* Ability Progress Bar Styling */
 .ability {
-	position: relative;
-	display: grid;
-	grid-template-columns: auto 1fr auto auto;
-	align-items: center;
-	gap: 0.1rem;
-	padding: 0.1rem 0.6rem;
-	border-radius: 0.5rem;
-	background: rgba(34, 33, 33, 0.568);
-	font-size: 0.65rem;
-	overflow: hidden;
+        position: relative;
+        display: grid;
+        grid-template-columns: auto auto auto 1fr auto auto;
+        align-items: center;
+        gap: 0.1rem;
+        padding: 0.1rem 0.6rem;
+        border-radius: 0.5rem;
+        background: rgba(34, 33, 33, 0.568);
+        font-size: 0.65rem;
+        overflow: hidden;
+}
+.drag-handle {
+        cursor: grab;
+        font-size: 0.8rem;
+        padding-right: 0.3rem;
+        user-select: none;
+        position: relative;
+        z-index: 1;
+}
+.ability-order {
+        width: 1rem;
+        text-align: center;
+        font-weight: 600;
+        position: relative;
+        z-index: 1;
 }
 
 .ability-fill {

--- a/src/ui/Screens/hunt.html
+++ b/src/ui/Screens/hunt.html
@@ -9,19 +9,21 @@
         <!-- row 1: player + enemy cards (auto-filled by JS) -->
         <div class="char-holders">
             <div class="char-card player" id="char-card-player">
-                <!-- add .enemy for foes -->
-                <!-- 1. Name -->
-                <h2 class="char-card__name">Player</h2>
-                <!-- 2. HP + Portrait -->
+                <!-- Card header: name & affinities -->
+                <div class="char-card__header">
+                    <h2 class="char-card__name">Player</h2>
+                    <div class="affinity-row"></div>
+                </div>
+                <!-- HP + Portrait -->
                 <div class="char-card__row">
                     <div class="health-stack">
-                        <small class="hp-label">132 / 200 HP</small>
-                        <div class="health-bar" style="--hunt-hp: 0.66">
-                            <span class="hp-fill"></span>
-                        </div>
                         <small class="stamina-label">50 / 100 ST</small>
                         <div class="stamina-bar" style="--hunt-stamina: 1">
                             <span class="stamina-fill"></span>
+                        </div>
+                        <small class="hp-label">132 / 200 HP</small>
+                        <div class="health-bar" style="--hunt-hp: 0.66">
+                            <span class="hp-fill"></span>
                         </div>
                     </div>
 
@@ -63,21 +65,22 @@
                 <!-- 4. Stats -->
             </div>
             <div class="char-card enemy" id="char-card-enemy">
-                <!-- add .enemy for foes -->
-                <!-- 1. Name -->
-                <h2 class="char-card__name">Player</h2>
-                <div class="affinity-row affinity-row"></div>
+                <!-- Card header: name & affinities -->
+                <div class="char-card__header">
+                    <h2 class="char-card__name">Player</h2>
+                    <div class="affinity-row affinity-row"></div>
+                </div>
 
-                <!-- 2. HP + Portrait -->
+                <!-- HP + Portrait -->
                 <div class="char-card__row">
                     <div class="health-stack">
-                        <small class="hp-label">132 / 200 HP</small>
-                        <div class="health-bar" style="--hunt-hp: 0.66">
-                            <span class="hp-fill"></span>
-                        </div>
                         <small class="stamina-label">50 / 100 ST</small>
                         <div class="stamina-bar" style="--hunt-stamina: 1">
                             <span class="stamina-fill"></span>
+                        </div>
+                        <small class="hp-label">132 / 200 HP</small>
+                        <div class="health-bar" style="--hunt-hp: 0.66">
+                            <span class="hp-fill"></span>
                         </div>
                     </div>
 

--- a/src/ui/components/CharacterDisplay.ts
+++ b/src/ui/components/CharacterDisplay.ts
@@ -64,18 +64,26 @@ export class CharacterDisplay extends UIBase {
 		this.abilitiesListMap.clear();
 		this.abilitiesListEl.innerHTML = "";
 
-		abilities.forEach((ability) => {
-			const li = document.createElement("li");
-			li.className = "ability";
-			li.dataset.abilityId = ability.id;
-			li.setAttribute("draggable", "true");
+                abilities.forEach((ability, idx) => {
+                        const li = document.createElement("li");
+                        li.className = "ability";
+                        li.dataset.abilityId = ability.id;
+                        li.setAttribute("draggable", "true");
 
-			// Create the fill element that will show progress
-			const fill = document.createElement("span");
-			fill.className = "ability-fill ability-fill--smooth"; // Add smooth class
+                        // Create the fill element that will show progress
+                        const fill = document.createElement("span");
+                        fill.className = "ability-fill ability-fill--smooth"; // Add smooth class
 
-			const iconImg = document.createElement("span");
-			iconImg.className = "ability-icon";
+                        const handle = document.createElement("span");
+                        handle.className = "drag-handle";
+                        handle.innerHTML = "&#9776;";
+
+                        const order = document.createElement("span");
+                        order.className = "ability-order";
+                        order.textContent = String(idx + 1);
+
+                        const iconImg = document.createElement("span");
+                        iconImg.className = "ability-icon";
 			//iconImg.className = "icon";
 			iconImg.style.backgroundImage = `url(${ability.spec.iconUrl})`;
 			iconImg.style.backgroundSize = "cover";
@@ -122,11 +130,13 @@ export class CharacterDisplay extends UIBase {
 			});
 			li.addEventListener("mouseleave", () => Tooltip.instance.hide());
 
-			li.appendChild(fill);
-			li.appendChild(iconImg);
-			li.appendChild(name);
-			li.appendChild(dmg);
-			li.appendChild(toggle);
+                        li.appendChild(fill);
+                        li.appendChild(handle);
+                        li.appendChild(order);
+                        li.appendChild(iconImg);
+                        li.appendChild(name);
+                        li.appendChild(dmg);
+                        li.appendChild(toggle);
 			this.abilitiesListEl.appendChild(li);
 
 			this.abilitiesListMap.set(ability.id, li);
@@ -156,9 +166,9 @@ export class CharacterDisplay extends UIBase {
 		this.staminaBar.style.setProperty("--hunt-stamina", stamina.percent);
 		this.staminaLabel.textContent = `${stamina.current} / ${stamina.max} ST`;
 
-		abilities.forEach((ability) => {
-			const bar = this.abilitiesListMap.get(ability.id);
-			if (!bar) return;
+                abilities.forEach((ability, i) => {
+                        const bar = this.abilitiesListMap.get(ability.id);
+                        if (!bar) return;
 
 			const toggle = bar.querySelector(".ability-toggle") as HTMLInputElement;
 			if (toggle) toggle.checked = ability.enabled;
@@ -168,8 +178,13 @@ export class CharacterDisplay extends UIBase {
 			// When currentCooldown equals maxCooldown, ability just used (0%)
 			const readinessRatio = ability.maxCooldown > 0 ? 1 - ability.currentCooldown / ability.maxCooldown : 1; // Default to ready if no cooldown
 
-			this.updateAbilityProgress(ability.id, bar, readinessRatio);
-		});
+                        const orderEl = bar.querySelector(
+                                ".ability-order"
+                        ) as HTMLElement | null;
+                        if (orderEl) orderEl.textContent = String(i + 1);
+
+                        this.updateAbilityProgress(ability.id, bar, readinessRatio);
+                });
 
 		this.renderStatusEffects();
 		this.createStatsGrid();
@@ -231,13 +246,17 @@ export class CharacterDisplay extends UIBase {
 		this.activeTransitions.clear();
 	}
 
-	private updateAbilityOrder() {
-		Array.from(this.abilitiesListEl.children).forEach((c, i) => {
-			const id = (c as HTMLElement).dataset.abilityId!;
-			const ability = this.character.getAbility(id);
-			if (ability) ability.priority = i;
-		});
-	}
+        private updateAbilityOrder() {
+                Array.from(this.abilitiesListEl.children).forEach((c, i) => {
+                        const id = (c as HTMLElement).dataset.abilityId!;
+                        const ability = this.character.getAbility(id);
+                        if (ability) ability.priority = i;
+                        const orderEl = (c as HTMLElement).querySelector(
+                                ".ability-order"
+                        ) as HTMLElement | null;
+                        if (orderEl) orderEl.textContent = String(i + 1);
+                });
+        }
 
 	private createStatsGrid() {
 		this.statGridEl.innerHTML = "";


### PR DESCRIPTION
## Summary
- tweak char card layout in hunt.html
- flip enemy card layout and add header section
- style character cards with new header, ability list box and draggable handles
- add drag handle and priority display in CharacterDisplay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ba1ed8aac8330992e62bf24a18656