### PR TITLE
Streamline CSS

### DIFF
--- a/css/hunt.css
+++ b/css/hunt.css
@@ -357,17 +357,7 @@
 	width: calc(var(--hunt-stamina, 0) * 100%);
 }
 
-.stamina-label {
-	align-self: flex-end;
-	font-size: 0.7rem;
-	opacity: 0.85;
-}
 
-.hp-label {
-	align-self: flex-end;
-	font-size: 0.88rem;
-	opacity: 0.85;
-}
 
 /* 3. Ability List */
 .ability-list {
@@ -443,10 +433,9 @@
 }
 
 .ability-icon,
-.ability-name,
 .ability-dmg {
-	position: relative;
-	z-index: 1;
+        position: relative;
+        z-index: 1;
 }
 
 /* Different colors for player vs enemy abilities */
@@ -473,9 +462,6 @@
 	text-align: center;
 }
 
-.ability-name {
-	font-weight: 500;
-}
 
 .ability-dmg {
 	font-weight: 600;

--- a/css/library.css
+++ b/css/library.css
@@ -12,11 +12,6 @@
 	flex-direction: column;
 	gap: 1rem;
 }
-.library-section-header {
-	font-size: 1.3rem;
-	font-weight: 600;
-	color: var(--primary-text, #fff);
-}
 .library-section-speed {
 	font-size: 0.8rem;
 	font-weight: 600;

--- a/css/mine.css
+++ b/css/mine.css
@@ -7,14 +7,6 @@
 	width: 100%;
 	margin: 0 auto;
 }
-.mine-section-header {
-	font-size: 1.5rem;
-	font-weight: 600;
-	letter-spacing: 0.02em;
-	margin-bottom: 0.5rem;
-	color: var(--primary-text, #fff);
-	text-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-}
 .mine-resource-list {
 	display: flex;
 	flex-direction: column;

--- a/css/settlement.css
+++ b/css/settlement.css
@@ -84,11 +84,6 @@
 	position: relative;
 	color: #a7e3ff;
 }
-.building-row .building-title {
-	font-weight: 700;
-	font-size: 1.08rem;
-	margin: 10px 0 3px 0;
-}
 
 .building-info .building-header {
 	font-weight: 300;

--- a/css/style.css
+++ b/css/style.css
@@ -115,10 +115,24 @@ h4 {
 }
 
 .basic-subtitle {
-	color: white;
-	font-size: 1rem; /* 16px */
-	font-weight: 500;
-	line-height: normal;
+        color: white;
+        font-size: 1rem; /* 16px */
+        font-weight: 500;
+        line-height: normal;
+}
+
+.basic-small {
+        color: white;
+        font-size: 0.875rem; /* 14px */
+        font-weight: 500;
+        line-height: normal;
+}
+
+.basic-very-small {
+        color: white;
+        font-size: 0.75rem; /* 12px */
+        font-weight: 500;
+        line-height: normal;
 }
 
 .basic-text {

--- a/src/ui/Screens/hunt.html
+++ b/src/ui/Screens/hunt.html
@@ -17,11 +17,11 @@
                 <!-- HP + Portrait -->
                 <div class="char-card__row">
                     <div class="health-stack">
-                        <small class="stamina-label">50 / 100 ST</small>
+                        <small class="stamina-label basic-small">50 / 100 ST</small>
                         <div class="stamina-bar" style="--hunt-stamina: 1">
                             <span class="stamina-fill"></span>
                         </div>
-                        <small class="hp-label">132 / 200 HP</small>
+                        <small class="hp-label basic-small">132 / 200 HP</small>
                         <div class="health-bar" style="--hunt-hp: 0.66">
                             <span class="hp-fill"></span>
                         </div>
@@ -57,7 +57,7 @@
                     <li class="ability" style="--hunt-cd: 0.35">
                         <span class="ability-fill"></span>
                         <span class="ability-icon">🔥</span>
-                        <span class="ability-name">Fireball</span>
+                        <span class="ability-name basic-very-small">Fireball</span>
                         <span class="ability-dmg">21</span>
                     </li>
                     <!-- clone & update these via JS -->
@@ -74,11 +74,11 @@
                 <!-- HP + Portrait -->
                 <div class="char-card__row">
                     <div class="health-stack">
-                        <small class="stamina-label">50 / 100 ST</small>
+                        <small class="stamina-label basic-small">50 / 100 ST</small>
                         <div class="stamina-bar" style="--hunt-stamina: 1">
                             <span class="stamina-fill"></span>
                         </div>
-                        <small class="hp-label">132 / 200 HP</small>
+                        <small class="hp-label basic-small">132 / 200 HP</small>
                         <div class="health-bar" style="--hunt-hp: 0.66">
                             <span class="hp-fill"></span>
                         </div>
@@ -114,7 +114,7 @@
                     <li class="ability" style="--hunt-cd: 0.35">
                         <span class="ability-fill"></span>
                         <span class="ability-icon">🔥</span>
-                        <span class="ability-name">Fireball</span>
+                        <span class="ability-name basic-very-small">Fireball</span>
                         <span class="ability-dmg">21</span>
                     </li>
                     <!-- clone & update these via JS -->

--- a/src/ui/Screens/library.html
+++ b/src/ui/Screens/library.html
@@ -1,10 +1,10 @@
 <div class="library-page">
     <div id="library-building-status"></div>
     <div class="library-left">
-        <div class="library-section-header">Current Research</div>
+        <div class="basic-title">Current Research</div>
         <span class="library-section-speed" id="library-section-speed">Research Speed</span>
         <div class="library-active-list" id="libraryActiveList"></div>
-        <div class="library-section-header">Available Research</div>
+        <div class="basic-title">Available Research</div>
         <div class="library-upgrade-grid" id="libraryUpgradeGrid"></div>
     </div>
     <div class="library-right">

--- a/src/ui/Screens/mine.html
+++ b/src/ui/Screens/mine.html
@@ -1,6 +1,6 @@
 <div class="mine-page">
     <div id="mine-building-status"></div>
-    <div class="mine-section-header">Mine Resources</div>
+    <div class="basic-title">Mine Resources</div>
     <div class="mine-resource-list" id="mineResourceList"></div>
     <div class="mine-output" id="mineOutput"></div>
 </div>

--- a/src/ui/Screens/settlement.html
+++ b/src/ui/Screens/settlement.html
@@ -5,7 +5,7 @@
             <div class="building-info">
                 <div class="building-header">
                     <div class="building-level"></div>
-                    <div class="building-title"></div>
+                    <div class="building-title basic-subtitle"></div>
                 </div>
                 <div class="progress-holder">
                     <div class="progress-text"></div>

--- a/src/ui/components/CharacterDisplay.ts
+++ b/src/ui/components/CharacterDisplay.ts
@@ -90,9 +90,9 @@ export class CharacterDisplay extends UIBase {
 			iconImg.style.backgroundPosition = "center";
 			iconImg.style.backgroundRepeat = "no-repeat";
 
-			const name = document.createElement("span");
-			name.className = "ability-name";
-			name.textContent = ability.name;
+                        const name = document.createElement("span");
+                        name.className = "ability-name basic-very-small";
+                        name.textContent = ability.name;
 
 			const dmg = document.createElement("span");
 			dmg.className = "ability-dmg";


### PR DESCRIPTION
## Summary
- add `basic-small` and `basic-very-small` helpers
- drop specialty headers in library and mine styles
- remove unused hunt label classes
- use new basic classes in settlement, hunt, mine and library screens
- style ability names with `basic-very-small`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d163d17fc833089ce22d4169c9eb8