### PR TITLE
Centralize combat logic in CombatManager

### DIFF
--- a/src/balance/GameBalance.ts
+++ b/src/balance/GameBalance.ts
@@ -141,9 +141,9 @@ export const GAME_BALANCE = {
 	},
 
 	// === COMBAT SCALING ===
-	combat: {
-		// Defense mitigation constant (from EffectProcessor.ts)
-		defenseConstant: 100,
+        combat: {
+                // Defense mitigation constant (used in CombatCalculator)
+                defenseConstant: 100,
 
 		// Damage variance range
 		damageVariance: {


### PR DESCRIPTION
## Summary
- remove combat update helpers from `BaseCharacter`
- move combat updates and ability readiness logic to `CombatManager`
- apply ability modifiers when calculating damage
- update GameBalance comment referencing CombatCalculator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861047e9e4883309dde2901e81aa9a2