### PR TITLE
Move debug stats into debug menu columns

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -757,18 +757,24 @@ h4 {
 }
 
 #debug-menu.debug-panel {
-	position: fixed;
-	bottom: 3.5rem;
-	right: 1rem;
-	z-index: 10000;
-	background: rgba(40, 40, 40, 0.9);
-	padding: 0.5rem 0.75rem;
-	color: #fff;
-	border-radius: 8px;
-	display: flex;
-	flex-direction: column;
-	gap: 0.3rem;
-	max-width: 260px;
+        position: fixed;
+        bottom: 3.5rem;
+        right: 1rem;
+        z-index: 10000;
+        background: rgba(40, 40, 40, 0.9);
+        padding: 0.5rem 0.75rem;
+        color: #fff;
+        border-radius: 8px;
+        display: flex;
+        gap: 0.5rem;
+        max-width: 800px;
+        align-items: flex-start;
+}
+
+#debug-menu .debug-column {
+        max-height: 300px;
+        overflow-y: auto;
+        width: 240px;
 }
 
 #debug-menu .debug-option {

--- a/src/core/EventBus.ts
+++ b/src/core/EventBus.ts
@@ -89,10 +89,11 @@ export interface GameEvents {
 	"stats:areaStatsChanged": AreaStats;
 	"stats:gameStatsChanged": GameStats;
 	"stats:prestigeStatsChanged": PrestigeStats;
-	"milestone:achieved": MilestoneEventPayload;
-	//------------------ DEBUG ---------------------
-	"debug:killEnemy": void;
-	// ------------------ GAME RUN ------------------------
+        "milestone:achieved": MilestoneEventPayload;
+        //------------------ DEBUG ---------------------
+        "debug:killEnemy": void;
+        "debug:statsUpdate": { isPlayer: boolean; data: string };
+        // ------------------ GAME RUN ------------------------
 	"gameRun:started": GameRun;
 	"gameRun:initialized": GameRun;
 	"gameRun:ended": RunStats;

--- a/src/ui/components/Debug-Menu.ts
+++ b/src/ui/components/Debug-Menu.ts
@@ -8,20 +8,42 @@ import { OfflineSession } from "@/models/OfflineProgress";
 import { BalanceDebug } from "@/balance/GameBalance";
 
 export class DebugMenu {
-	private rootEl!: HTMLElement;
-	private toggleBtn!: HTMLButtonElement;
-	constructor() {}
+        private rootEl!: HTMLElement;
+        private toggleBtn!: HTMLButtonElement;
+        private optionsEl!: HTMLElement;
+        private playerStatsEl!: HTMLElement;
+        private enemyStatsEl!: HTMLElement;
+        constructor() {}
 
-	build() {
-		this.rootEl = document.getElementById("debug-menu")!;
-		this.rootEl.innerHTML = "";
-		this.rootEl.classList.add("debug-panel");
-		this.rootEl.style.display = "none";
+        build() {
+                this.rootEl = document.getElementById("debug-menu")!;
+                this.rootEl.innerHTML = "";
+                this.rootEl.classList.add("debug-panel");
+                this.rootEl.style.display = "none";
 
-		this.buildToggleButton();
-		this.buildControls();
-		this.addActions();
-	}
+                this.optionsEl = document.createElement("div");
+                this.optionsEl.className = "debug-column options";
+                this.playerStatsEl = document.createElement("pre");
+                this.playerStatsEl.className = "debug-column player-stats";
+                this.enemyStatsEl = document.createElement("pre");
+                this.enemyStatsEl.className = "debug-column enemy-stats";
+
+                this.rootEl.appendChild(this.optionsEl);
+                this.rootEl.appendChild(this.playerStatsEl);
+                this.rootEl.appendChild(this.enemyStatsEl);
+
+                bus.on("debug:statsUpdate", (payload) => {
+                        if (payload.isPlayer) {
+                                this.playerStatsEl.textContent = payload.data;
+                        } else {
+                                this.enemyStatsEl.textContent = payload.data;
+                        }
+                });
+
+                this.buildToggleButton();
+                this.buildControls();
+                this.addActions();
+        }
 
 	private buildToggleButton() {
 		this.toggleBtn = document.createElement("button");
@@ -77,7 +99,7 @@ export class DebugMenu {
 		});
 		wrap.appendChild(input);
 		wrap.appendChild(document.createTextNode(label));
-		this.rootEl.appendChild(wrap);
+                this.optionsEl.appendChild(wrap);
 	}
 
 	private addNumber(label: string, key: keyof DebugOptions, step: number) {
@@ -94,7 +116,7 @@ export class DebugMenu {
 		});
 		wrap.appendChild(span);
 		wrap.appendChild(input);
-		this.rootEl.appendChild(wrap);
+                this.optionsEl.appendChild(wrap);
 	}
 
 	private addActions() {
@@ -174,11 +196,11 @@ export class DebugMenu {
 		printLog(`Attack ${rolledCrit ? "[CRIT]" : ""} : ${final} `, 1, "Debug-Menu.ts");
 	}
 
-	private addButton(name: string, onClick: () => void) {
-		const btn = document.createElement("button");
-		btn.classList.add("button");
-		btn.textContent = name;
-		this.rootEl.appendChild(btn);
-		btn.addEventListener("click", onClick);
-	}
+        private addButton(name: string, onClick: () => void) {
+                const btn = document.createElement("button");
+                btn.classList.add("button");
+                btn.textContent = name;
+                this.optionsEl.appendChild(btn);
+                btn.addEventListener("click", onClick);
+        }
 }


### PR DESCRIPTION
## Summary
- show player and enemy debug stats within the debug menu
- expose `debug:statsUpdate` bus event
- emit stats from `CharacterDisplay` each render
- style debug menu columns so they're scrollable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68613b6f7da48330a582ac7b2a4129c4