### PR TITLE
Add HP change popups

### DIFF
--- a/css/hunt.css
+++ b/css/hunt.css
@@ -269,10 +269,54 @@
 
 /* health stack */
 .health-stack {
-	flex: 1;
-	display: flex;
-	flex-direction: column;
-	gap: 0.85rem;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 0.85rem;
+        position: relative;
+}
+
+.hp-change {
+        position: absolute;
+        left: 50%;
+        top: -0.2rem;
+        transform: translateX(-50%);
+        pointer-events: none;
+        opacity: 0;
+}
+
+.hp-change.damage {
+        color: #f87171;
+}
+
+.hp-change.heal {
+        color: #4ade80;
+}
+
+.hp-change.crit {
+        font-weight: 700;
+}
+
+.hp-change.show {
+        animation: hp-bounce 1s ease-out forwards;
+}
+
+@keyframes hp-bounce {
+        0% {
+                transform: translate(-50%, 0) scale(0.8);
+                opacity: 0;
+        }
+        20% {
+                transform: translate(-50%, -4px) scale(1.1);
+                opacity: 1;
+        }
+        40% {
+                transform: translate(-50%, -8px) scale(1);
+        }
+        100% {
+                transform: translate(-50%, -20px) scale(1);
+                opacity: 0;
+        }
 }
 
 /* 3. Ability List */

--- a/src/core/EventBus.ts
+++ b/src/core/EventBus.ts
@@ -10,6 +10,7 @@ import { GameRun, RunStats } from "./GameRun";
 import { Resource } from "@/features/inventory/Resource";
 import { ModifierSystem } from "./ModifierEngine";
 import { Area } from "@/models/Area";
+import { BaseCharacter } from "@/models/BaseCharacter";
 
 export interface GameEvents {
 	"Game:UITick": number;
@@ -56,9 +57,10 @@ export interface GameEvents {
 	"player:statsChanged": PlayerCharacter;
 
 	// PLAYER CHARACTER
-	"char:levelUp": number; // New Level
-	"char:gainedXp": number; // Amount incoming
-	"classes:pointsChanged": void;
+        "char:levelUp": number; // New Level
+        "char:gainedXp": number; // Amount incoming
+        "char:hpChanged": { char: BaseCharacter; amount: number; isCrit?: boolean };
+        "classes:pointsChanged": void;
 	"classes:nodesChanged": void;
 
 	//HUNT

--- a/src/features/hunt/CombatCalculator.ts
+++ b/src/features/hunt/CombatCalculator.ts
@@ -6,12 +6,12 @@ export class CombatCalculator {
 	 * Calculate damage for any attack
 	 * Single source of truth for all damage calculations
 	 */
-	static calculateDamage(
-		attacker: BaseCharacter,
-		defender: BaseCharacter,
-		baseDamageMultiplier: number,
-		element: ElementType = "physical"
-	): number {
+        static calculateDamage(
+                attacker: BaseCharacter,
+                defender: BaseCharacter,
+                baseDamageMultiplier: number,
+                element: ElementType = "physical"
+        ): { damage: number; isCrit: boolean } {
 		// Step 1: Get attacker's base attack
 		const baseAttack = attacker.stats.get("attack");
 
@@ -49,8 +49,8 @@ export class CombatCalculator {
 		// Resistance as percentage: positive reduces damage, negative increases
 		const finalDamage = afterDefense * (1 - totalResistance / 100);
 
-		// Always deal at least 1 damage
-		return Math.max(1, Math.floor(finalDamage));
+                // Always deal at least 1 damage
+                return { damage: Math.max(1, Math.floor(finalDamage)), isCrit };
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- show floating HP changes for characters
- color healed or damaged numbers and bold crits
- emit new `char:hpChanged` bus event
- surface HP changes during abilities and periodic effects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861ac4c482883309ed64122b524a7bf