### PR TITLE
Ensure prestige resets resources and blacksmith

### DIFF
--- a/src/features/inventory/ResourceManager.ts
+++ b/src/features/inventory/ResourceManager.ts
@@ -108,9 +108,33 @@ export class ResourceManager extends Destroyable implements Saveable {
 		return this.resources.get(id);
 	}
 
-	public getAllResources(): Map<string, ResourceData> {
-		return new Map(Array.from(this.resources.entries()).map(([key, value]) => [key, { ...value }]));
-	}
+        public getAllResources(): Map<string, ResourceData> {
+                return new Map(Array.from(this.resources.entries()).map(([key, value]) => [key, { ...value }]));
+        }
+
+        /** Calculate the total starting amount for a resource based on its level */
+        public getPrestigeStartAmount(resourceId: string): number {
+                return this.getActiveUpgrades(resourceId).reduce(
+                        (total, upg) => total + (upg.effects.prestigeStartAmount || 0),
+                        0
+                );
+        }
+
+        /** Apply saved resource levels and set quantities for a new prestige run */
+        public applyPrestigeResources(data: Map<string, ResourceData>): void {
+                data.forEach((saved, id) => {
+                        const current = this.resources.get(id);
+                        if (!current) return;
+                        current.level = saved.level;
+                        current.xp = saved.xp;
+                        current.infinite = saved.infinite;
+                        current.isUnlocked = saved.isUnlocked;
+                        current.quantity = current.infinite
+                                ? Number.MAX_SAFE_INTEGER
+                                : this.getPrestigeStartAmount(id);
+                });
+                this.emitChange();
+        }
 
 	public getAllUpgrades(resourceId: string): ResourceUpgradeEffect[] {
 		return RESOURCE_UPGRADES;


### PR DESCRIPTION
## Summary
- reset blacksmith slots on prestige
- preserve resource levels but clear quantities when prestiging
- start new run with resources based on level bonuses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865754603748330a9157f103541c78f