### PR TITLE
Implement multi-level upgrades

### DIFF
--- a/css/UIComponents.css
+++ b/css/UIComponents.css
@@ -558,13 +558,14 @@ section + section {
 }
 
 .upgrade-card {
-	background: rgba(0, 0, 0, 0.25);
-	border-radius: 6px;
-	padding: 0.6rem;
-	display: flex;
-	flex-direction: column;
-	gap: 0.4rem;
-	color: #fff;
+        position: relative;
+        background: rgba(0, 0, 0, 0.25);
+        border-radius: 6px;
+        padding: 0.6rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+        color: #fff;
 }
 .upgrade-card.purchased {
 	opacity: 0.5;
@@ -581,8 +582,14 @@ section + section {
 	color: var(--text-muted, #ccc);
 }
 .upgrade-level {
-	font-size: 0.8rem;
-	opacity: 0.8;
+        position: absolute;
+        bottom: 4px;
+        right: 6px;
+        font-size: 0.75rem;
+        background: rgba(0, 0, 0, 0.6);
+        padding: 0 4px;
+        border-radius: 4px;
+        pointer-events: none;
 }
 .upgrade-progress {
 	display: flex;

--- a/src/data/upgrades.json
+++ b/src/data/upgrades.json
@@ -1,47 +1,52 @@
 {
 	"research": [
-		{
-			"id": "xp_boost_1",
-			"name": "Basic Monster Lore",
-			"description": "Monsters yield 10% more experience.",
-			"icon": "icons/book1.png",
-			"baseTime": 600,
-			"unlocks": { "type": "additive", "property": "combat_xp", "amt": 10 }
-		},
-		{
-			"id": "resource_boost_1",
-			"name": "Efficient Gathering",
-			"description": "Prestiging grants 2% more permanent resources.",
-			"icon": "icons/book2.png",
-			"baseTime": 900,
-			"unlocks": { "type": "additive", "property": "prestige_rewards", "amt": 2 }
-		},
-		{
-			"id": "library_speed",
-			"name": "Improved Scribes",
-			"description": "Research speed increased by 10%.",
-			"icon": "icons/book3.png",
-			"baseTime": 1200,
-			"unlocks": { "type": "additive", "property": "researchSpeed", "amt": 10 }
-		}
+                {
+                        "id": "xp_boost_1",
+                        "name": "Basic Monster Lore",
+                        "description": "Monsters yield 10% more experience.",
+                        "icon": "icons/book1.png",
+                        "baseTime": 600,
+                        "maxLevel": 1,
+                        "unlocks": { "type": "additive", "property": "combat_xp", "amt": 10 }
+                },
+                {
+                        "id": "resource_boost_1",
+                        "name": "Efficient Gathering",
+                        "description": "Prestiging grants 2% more permanent resources.",
+                        "icon": "icons/book2.png",
+                        "baseTime": 900,
+                        "maxLevel": 1,
+                        "unlocks": { "type": "additive", "property": "prestige_rewards", "amt": 2 }
+                },
+                {
+                        "id": "library_speed",
+                        "name": "Improved Scribes",
+                        "description": "Research speed increased by 10%.",
+                        "icon": "icons/book3.png",
+                        "baseTime": 1200,
+                        "maxLevel": 1,
+                        "unlocks": { "type": "additive", "property": "researchSpeed", "amt": 10 }
+                }
 	],
 	"blacksmith": [
-		{
-			"id": "slot_2",
-			"name": "Extra Slot",
-			"description": "Unlock an additional crafting slot.",
-			"cost": [
-				{ "resource": "iron_ingot", "quantity": 1000 },
-				{ "resource": "charstone", "quantity": 100000 }
-			],
-			"icon": ""
-		},
-		{
-			"id": "better_tools",
-			"name": "Better Tools",
-			"description": "Craft 20% faster.",
-			"cost": [{ "resource": "iron_ingot", "quantity": 100 }],
-			"icon": ""
-		}
-	]
+                {
+                        "id": "slot_2",
+                        "name": "Extra Slot",
+                        "description": "Unlock an additional crafting slot.",
+                        "cost": [
+                                { "resource": "iron_ingot", "quantity": 1000 },
+                                { "resource": "charstone", "quantity": 100000 }
+                        ],
+                        "icon": "",
+                        "maxLevel": 1
+                },
+                {
+                        "id": "better_tools",
+                        "name": "Better Tools",
+                        "description": "Craft 20% faster.",
+                        "cost": [{ "resource": "iron_ingot", "quantity": 100 }],
+                        "icon": "",
+                        "maxLevel": 1
+                }
+        ]
 }

--- a/src/features/settlement/BlacksmithUpgrade.ts
+++ b/src/features/settlement/BlacksmithUpgrade.ts
@@ -2,7 +2,7 @@ import { BlacksmithUpgradeSpec, ResourceRequirement } from "@/shared/types";
 import { SpecRegistryBase } from "@/models/SpecRegistryBase";
 
 export class BlacksmithUpgrade extends SpecRegistryBase<BlacksmithUpgradeSpec> {
-    private constructor(private readonly spec: BlacksmithUpgradeSpec, private purchased = false) {
+    private constructor(private readonly spec: BlacksmithUpgradeSpec, private level = 0) {
         super();
     }
 
@@ -12,10 +12,18 @@ export class BlacksmithUpgrade extends SpecRegistryBase<BlacksmithUpgradeSpec> {
     get cost(): ResourceRequirement[] { return this.spec.cost; }
     get icon() { return this.spec.icon || ""; }
     get effect() { return this.spec.effect; }
-    get isPurchased() { return this.purchased; }
+    get maxLevel() { return this.spec.maxLevel ?? 1; }
+    get currentLevel() { return this.level; }
+    get isPurchased() { return this.level >= this.maxLevel; }
 
     purchase() {
-        this.purchased = true;
+        if (this.level < this.maxLevel) {
+            this.level += 1;
+        }
+    }
+
+    setLevel(level: number) {
+        this.level = Math.min(level, this.maxLevel);
     }
 
     public static override specById = new Map<string, BlacksmithUpgradeSpec>();

--- a/src/features/settlement/ResearchUpgrade.ts
+++ b/src/features/settlement/ResearchUpgrade.ts
@@ -3,23 +3,27 @@ import { SpecRegistryBase } from "@/models/SpecRegistryBase";
 import { debugManager } from "@/core/DebugManager";
 
 export class ResearchUpgrade extends SpecRegistryBase<ResearchSpec> {
-	private constructor(private readonly spec: ResearchSpec, private state: ResearchState) {
-		super();
-	}
+        private constructor(private readonly spec: ResearchSpec, private state: ResearchState) {
+                super();
+        }
 
-	tick(dt: number, speed: number) {
-		if (this.state.unlocked) return;
-		// Debug - Instant Research Unlock
-		if (debugManager.get("research_instantResearch")) {
-			this.state.progress = this.spec.baseTime;
-			this.state.unlocked = true;
-			return;
-		}
-		this.state.progress += dt * speed;
-		if (this.state.progress >= this.spec.baseTime) {
-			this.state.unlocked = true;
-		}
-	}
+        tick(dt: number, speed: number): boolean {
+                if (this.unlocked) return false;
+                // Debug - Instant Research Unlock
+                if (debugManager.get("research_instantResearch")) {
+                        this.state.progress = this.spec.baseTime;
+                }
+                this.state.progress += dt * speed;
+                if (this.state.progress >= this.spec.baseTime) {
+                        this.state.progress = 0;
+                        this.state.level += 1;
+                        if (this.state.level >= this.maxLevel) {
+                                return true;
+                        }
+                        return true;
+                }
+                return false;
+        }
 
 	get id() {
 		return this.spec.id;
@@ -33,32 +37,42 @@ export class ResearchUpgrade extends SpecRegistryBase<ResearchSpec> {
 	get icon() {
 		return this.spec.icon;
 	}
-	get progress() {
-		return this.state.progress;
-	}
-	get requiredTime() {
-		return this.spec.baseTime;
-	}
-	get unlocked() {
-		return this.state.unlocked;
-	}
+        get progress() {
+                return this.state.progress;
+        }
+        get requiredTime() {
+                return this.spec.baseTime;
+        }
+        get unlocked() {
+                return this.state.level >= this.maxLevel;
+        }
+        get level() {
+                return this.state.level;
+        }
+        get maxLevel() {
+                return this.spec.maxLevel ?? 1;
+        }
 
 	toJSON() {
-		return { __type: "ResearchUpgrade", spec: this.spec.id, state: this.state };
-	}
+                return { __type: "ResearchUpgrade", spec: this.spec.id, state: this.state };
+        }
 
 	static fromJSON(raw: any) {
-		const spec = this.specById.get(raw.spec);
-		if (!spec) throw new Error(`Unknown research ${raw.spec}`);
-		return new ResearchUpgrade(spec, raw.state);
-	}
+                const spec = this.specById.get(raw.spec);
+                if (!spec) throw new Error(`Unknown research ${raw.spec}`);
+                return new ResearchUpgrade(spec, raw.state);
+        }
 
 	public static override specById = new Map<string, ResearchSpec>();
 
-	static create(id: string): ResearchUpgrade {
-		const spec = this.specById.get(id);
-		if (!spec) throw new Error(`Unknown research ${id}`);
-		const defaultState: ResearchState = { progress: 0, unlocked: false };
-		return new ResearchUpgrade(spec, defaultState);
-	}
+        static create(id: string): ResearchUpgrade {
+                const spec = this.specById.get(id);
+                if (!spec) throw new Error(`Unknown research ${id}`);
+                const defaultState: ResearchState = { progress: 0, level: 0 };
+                return new ResearchUpgrade(spec, defaultState);
+        }
+
+        setLevel(level: number) {
+                this.state.level = Math.min(level, this.maxLevel);
+        }
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -40,25 +40,27 @@ export interface BuildingSnapshot {
 }
 
 export interface ResearchSpec {
-	id: string;
-	name: string;
-	description: string;
-	icon: string;
-	baseTime: number; // seconds required at base speed
+        id: string;
+        name: string;
+        description: string;
+        icon: string;
+        baseTime: number; // seconds required at base speed
+        maxLevel?: number; // how many times this research can be upgraded
 }
 
 export interface ResearchState {
-	progress: number;
-	unlocked: boolean;
+        progress: number;
+        level: number;
 }
 
 export interface BlacksmithUpgradeSpec {
-	id: string;
-	name: string;
-	description: string;
-	cost: ResourceRequirement[];
-	icon?: string;
-	effect?: string;
+        id: string;
+        name: string;
+        description: string;
+        cost: ResourceRequirement[];
+        icon?: string;
+        effect?: string;
+        maxLevel?: number; // number of times this upgrade can be purchased
 }
 
 // ------------------- AREA + COMBAT ------------------------------

--- a/src/ui/Screens/BlacksmithScreen.ts
+++ b/src/ui/Screens/BlacksmithScreen.ts
@@ -270,18 +270,20 @@ export class BlacksmithScreen extends BaseScreen {
 	}
 
 	private getUpgradeData(): UpgradeSelectionData[] {
-		return this.context.blacksmith.getUpgrades().map((upg) => ({
-			id: upg.id,
-			title: upg.name,
-			description: upg.description,
-			costs: upg.cost.map((c) => ({
-				icon: Resource.getSpec(c.resource)?.iconUrl ?? "",
-				amount: c.quantity,
-			})),
-			purchased: upg.isPurchased,
-			canAfford: this.context.resources.canAfford(upg.cost),
-		}));
-	}
+                return this.context.blacksmith.getUpgrades().map((upg) => ({
+                        id: upg.id,
+                        title: upg.name,
+                        description: upg.description,
+                        costs: upg.cost.map((c) => ({
+                                icon: Resource.getSpec(c.resource)?.iconUrl ?? "",
+                                amount: c.quantity,
+                        })),
+                        level: upg.currentLevel,
+                        maxLevel: upg.maxLevel,
+                        purchased: upg.isPurchased,
+                        canAfford: this.context.resources.canAfford(upg.cost),
+                }));
+        }
 
 	/**
 	 * Updates all UI elements.

--- a/src/ui/Screens/LibraryScreen.ts
+++ b/src/ui/Screens/LibraryScreen.ts
@@ -85,18 +85,20 @@ export class LibraryScreen extends BaseScreen {
 		});
 	}
 
-	private getAvailableUpgrades(): UpgradeSelectionData[] {
-		return this.context.library.getAvailable().map((upg) => ({
-			id: upg.id,
-			title: upg.name,
-			description: upg.description,
-			costs: [],
-			requiredTime: upg.requiredTime,
-			purchased: false,
-			canAfford: true,
-			buttonOverride: "Research",
-		}));
-	}
+        private getAvailableUpgrades(): UpgradeSelectionData[] {
+                return this.context.library.getAvailable().map((upg) => ({
+                        id: upg.id,
+                        title: upg.name,
+                        description: upg.description,
+                        costs: [],
+                        requiredTime: upg.requiredTime,
+                        level: upg.level,
+                        maxLevel: upg.maxLevel,
+                        purchased: false,
+                        canAfford: true,
+                        buttonOverride: "Research",
+                }));
+        }
 
 	private updateCompleted() {
 		const list = this.context.library.getCompleted();

--- a/src/ui/components/UpgradeSelectionComponent.ts
+++ b/src/ui/components/UpgradeSelectionComponent.ts
@@ -50,12 +50,12 @@ export class UpgradeSelectionComponent extends UIBase {
 		desc.textContent = data.description;
 		root.appendChild(desc);
 
-		if (data.level !== undefined) {
-			const level = document.createElement("div");
-			level.className = "upgrade-level";
-			level.textContent = `Lv ${data.level}`;
-			root.appendChild(level);
-		}
+                if (data.level !== undefined && data.maxLevel !== undefined) {
+                        const level = document.createElement("div");
+                        level.className = "upgrade-level";
+                        level.textContent = `${data.level}/${data.maxLevel}`;
+                        root.appendChild(level);
+                }
 
 		if (data.requiredTime) {
 			const progWrap = document.createElement("div");


### PR DESCRIPTION
## Summary
- add `maxLevel` fields in upgrade specs
- track levels for blacksmith and research upgrades
- persist upgrade levels in save data
- show upgrade level overlays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686794ed8a4c833094d17918950e9d24