### PR TITLE
Add automated test harness with skip states

### DIFF
--- a/src/core/DebugManager.ts
+++ b/src/core/DebugManager.ts
@@ -71,27 +71,29 @@ export class DebugManager {
 	}
 
 	// Save current overrides to localStorage
-	public saveToStorage(): void {
-		try {
-			const dataToSave = JSON.stringify(this.overrides);
-			localStorage.setItem(this.STORAGE_KEY, dataToSave);
-		} catch (error) {
-			console.warn("Failed to save debug settings:", error);
-		}
-	}
+        public saveToStorage(): void {
+                if (typeof localStorage === 'undefined') return;
+                try {
+                        const dataToSave = JSON.stringify(this.overrides);
+                        localStorage.setItem(this.STORAGE_KEY, dataToSave);
+                } catch (error) {
+                        console.warn("Failed to save debug settings:", error);
+                }
+        }
 
-	// Load overrides from localStorage
-	public loadFromStorage(): void {
-		try {
-			const saved = localStorage.getItem(this.STORAGE_KEY);
-			if (saved) {
-				const parsed = JSON.parse(saved) as Partial<DebugOptions>;
-				this.overrides = { ...this.overrides, ...parsed };
-			}
-		} catch (error) {
-			console.warn("Failed to load debug settings:", error);
-		}
-	}
+        // Load overrides from localStorage
+        public loadFromStorage(): void {
+                if (typeof localStorage === 'undefined') return;
+                try {
+                        const saved = localStorage.getItem(this.STORAGE_KEY);
+                        if (saved) {
+                                const parsed = JSON.parse(saved) as Partial<DebugOptions>;
+                                this.overrides = { ...this.overrides, ...parsed };
+                        }
+                } catch (error) {
+                        console.warn("Failed to load debug settings:", error);
+                }
+        }
 }
 
 export function printLog(msg: string, verbosity: number, sender?: string, type?: DebugType) {

--- a/src/tools/AutoTestRunner.ts
+++ b/src/tools/AutoTestRunner.ts
@@ -1,0 +1,80 @@
+import { initGameData } from '../core/gameData';
+import { GameServices } from '../core/GameServices';
+import { Player } from '../core/Player';
+import { GameContext } from '../core/GameContext';
+import { OfflineReason } from '../models/OfflineProgress';
+import { applySkipState } from './SkipStates';
+import './defaultSkipStates';
+import fs from 'fs';
+
+interface TestOptions {
+  hours: number;
+  skipState: number;
+}
+
+export class AutoTestRunner {
+  private context!: GameContext;
+
+  constructor(private options: TestOptions) {}
+
+  async setup() {
+    // Minimal DOM for HuntManager
+    (global as any).document = {
+      getElementById: () => ({ selectedIndex: 0 }),
+    } as Document;
+
+    initGameData();
+    const services = GameServices.getInstance();
+    const player = Player.initSingleton();
+    this.context = GameContext.initialize(player, services);
+    this.context.startNewRun(player.getPrestigeState(), true);
+    this.context.flags.isGameReady = true;
+  }
+
+  applySkipState() {
+    applySkipState(this.options.skipState, this.context);
+  }
+
+  runSimulation() {
+    const durationMs = this.options.hours * 3600 * 1000;
+    this.context.services.offlineManager.processOfflineSession({
+      startTime: Date.now(),
+      endTime: Date.now() + durationMs,
+      duration: durationMs,
+      reason: OfflineReason.Visibility,
+    });
+  }
+
+  collectResults() {
+    const stats = this.context.services.statsManager.getUserStats();
+    return {
+      hoursSimulated: this.options.hours,
+      level: stats.level,
+      renown: this.context.player.currentRenown,
+    };
+  }
+
+  outputResults(results: any) {
+    const dir = 'test-reports';
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir);
+    const file = `${dir}/report_${Date.now()}.json`;
+    fs.writeFileSync(file, JSON.stringify(results, null, 2));
+    console.log('Simulation results saved to', file);
+    console.log(JSON.stringify(results, null, 2));
+  }
+
+  async run() {
+    await this.setup();
+    this.applySkipState();
+    this.runSimulation();
+    const results = this.collectResults();
+    this.outputResults(results);
+  }
+}
+
+if (require.main === module) {
+  const hours = Number(process.argv[2] || '1');
+  const skipState = Number(process.argv[3] || '0');
+  const runner = new AutoTestRunner({ hours, skipState });
+  runner.run();
+}

--- a/src/tools/SkipStates.ts
+++ b/src/tools/SkipStates.ts
@@ -1,0 +1,18 @@
+export interface SkipState {
+  id: number;
+  description: string;
+  apply(context: import('../core/GameContext').GameContext): void;
+}
+
+export const skipStates: SkipState[] = [];
+
+export function registerSkipState(state: SkipState) {
+  skipStates[state.id] = state;
+}
+
+export function applySkipState(level: number, context: import('../core/GameContext').GameContext) {
+  for (let i = 0; i <= level && i < skipStates.length; i++) {
+    const state = skipStates[i];
+    if (state) state.apply(context);
+  }
+}

--- a/src/tools/defaultSkipStates.ts
+++ b/src/tools/defaultSkipStates.ts
@@ -1,0 +1,25 @@
+import { GameContext } from '../core/GameContext';
+import { registerSkipState } from './SkipStates';
+
+// Skipstate 0 - initial start
+registerSkipState({
+  id: 0,
+  description: 'Base game start',
+  apply: (ctx: GameContext) => {
+    ctx.stats.unlockArea('forest_easy');
+    ctx.hunt.setArea('forest_easy');
+  }
+});
+
+// Skipstate 1 - after first boss
+registerSkipState({
+  id: 1,
+  description: 'Defeated first boss, unlock next area and build guild',
+  apply: (ctx: GameContext) => {
+    // apply previous skipstates
+    ctx.stats.unlockArea('forest_easy');
+    ctx.stats.getAreaStats('forest_easy').bossKilledThisRun = true;
+    ctx.stats.unlockArea('duskwolf_grove');
+    ctx.settlement.changeBuildingStatus('guild_hall', 'built');
+  }
+});

--- a/src/ui/components/ToastManager.ts
+++ b/src/ui/components/ToastManager.ts
@@ -14,6 +14,13 @@ export class ToastManager {
     private current: HTMLElement | null = null;
 
     private constructor() {
+        if (typeof document === 'undefined') {
+            // Node/test environment - no DOM available
+            this.container = {
+                appendChild: () => {}
+            } as unknown as HTMLElement;
+            return;
+        }
         this.container = document.createElement('div');
         this.container.id = 'toast-container';
         this.container.className = 'toast-container';
@@ -28,6 +35,13 @@ export class ToastManager {
     }
 
     private showNext() {
+        if (typeof document === 'undefined') {
+            // In tests, just log and skip DOM operations
+            const next = this.queue.shift();
+            if (next) console.log(`[Toast] ${next.title}: ${next.text}`);
+            this.current = null;
+            return;
+        }
         if (this.queue.length === 0) {
             this.current = null;
             return;


### PR DESCRIPTION
## Summary
- add automated test runner to simulate long game sessions
- define skip state framework with sample states
- make ToastManager and DebugManager safe for node

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870d7708c1c83308a8b3b6310420401