### PR TITLE
Add renown-based heirloom progression

### DIFF
--- a/src/data/equipment.json
+++ b/src/data/equipment.json
@@ -8,6 +8,7 @@
         "statMod": { "defence": 1, "hp": 20 },
         "iconUrl": "/images/equipment/equipment-t1-chest-wornpaddedchest.png",
         "resistances": {},
+        "baseRenown": 100,
 
         "tags": ["t1"]
     },
@@ -20,6 +21,7 @@
         "statMod": { "defence": 3, "hp": 10 },
         "iconUrl": "",
         "resistances": {},
+        "baseRenown": 100,
         "tags": ["t1"]
     },
     {
@@ -30,6 +32,7 @@
         "equipType": "weapon",
         "statMod": { "attack": 4 },
         "iconUrl": "/images/equipment/equipment-t1-weapon-crackedsword.png",
+        "baseRenown": 100,
         "tags": ["t1"]
     },
     {
@@ -41,6 +44,7 @@
         "statMod": { "defence": 2, "hp": 10 },
         "iconUrl": "/images/equipment/equipment-t1-legs-rippedtrousers.png",
         "resistances": {},
+        "baseRenown": 100,
         "tags": ["t1"]
     },
     {
@@ -52,6 +56,7 @@
         "statMod": { "defence": 1, "hp": 5, "speed": 0.05 },
         "iconUrl": "",
         "resistances": {},
+        "baseRenown": 100,
         "tags": ["t1"]
     },
     {
@@ -63,6 +68,7 @@
         "statMod": { "defence": 1, "hp": 5, "critChance": 0.1 },
         "iconUrl": "",
         "resistances": {},
+        "baseRenown": 100,
         "tags": ["t1"]
     }
 ]

--- a/src/features/hunt/CombatManager.ts
+++ b/src/features/hunt/CombatManager.ts
@@ -180,6 +180,7 @@ export class CombatManager extends Destroyable {
         // Award renown
         const renownReward = BalanceCalculators.getMonsterRenown(this.area.tier, this.enemyCharacter.spec.rarity);
         this.context.player.adjustRenown(renownReward);
+        this.context.inventory.awardRenownToEquipped(renownReward);
 
         // Award experience
         const enemyId = this.enemyCharacter.spec.id;

--- a/src/features/inventory/InventoryItem.ts
+++ b/src/features/inventory/InventoryItem.ts
@@ -53,14 +53,38 @@ export abstract class InventoryItem<T extends EquipmentItemSpec> extends SpecReg
 	get description() {
 		return this.spec.description;
 	}
-	get statMod() {
-		return this.spec.statMod;
-	}
+        get statMod() {
+                return this.spec.statMod;
+        }
+        get renown() {
+                return this.state.renown ?? 0;
+        }
+        get renownRequired() {
+                return this.state.renownRequired ?? 0;
+        }
 
-	// We only add heirloom to equipped equipment during prestige.
-	public addHeirloom(amount: number) {
-		this.state.heirloom = (this.state.heirloom ?? 0) + amount;
-	}
+        // We only add heirloom to equipped equipment during prestige.
+        public addHeirloom(amount: number) {
+                this.state.heirloom = (this.state.heirloom ?? 0) + amount;
+        }
+
+        /** Add renown progress, capped at renownRequired */
+        public addRenown(amount: number) {
+                const req = this.state.renownRequired ?? 0;
+                const current = this.state.renown ?? 0;
+                this.state.renown = Math.min(current + amount, req);
+        }
+
+        /** Check if item is ready to prestige and apply heirloom level */
+        public tryPrestigeUpgrade(): boolean {
+                if ((this.state.renown ?? 0) >= (this.state.renownRequired ?? 0)) {
+                        this.addHeirloom(1);
+                        this.state.renown = 0;
+                        this.state.renownRequired = Math.ceil((this.state.renownRequired ?? 1) * 1.5);
+                        return true;
+                }
+                return false;
+        }
 
 	// Add levels to the item
 	// If over level 100, upgrade the rarity

--- a/src/features/inventory/InventoryManager.ts
+++ b/src/features/inventory/InventoryManager.ts
@@ -231,18 +231,28 @@ export class InventoryManager implements Saveable {
 
 	//------------------------ EQUIPMENT ------------------------------
 
-	public getEquippedEquipment(): Equipment[] {
-		return (
-			this.slots
-				// 1) Pick only the equipment‐slots that actually have something in them
-				.filter((slot) => slot.type === "equipment" && slot.itemState !== null)
-				// 2) For each one, grab its saved state, look up the latest spec, and construct an Equipment
-				.map((slot) => {
-					const state = slot.itemState!; // { id, quantity, rarity }
-					return Equipment.createFromState(state);
-				})
-		);
-	}
+        public getEquippedEquipment(): Equipment[] {
+                return (
+                        this.slots
+                                // 1) Pick only the equipment‐slots that actually have something in them
+                                .filter((slot) => slot.type === "equipment" && slot.itemState !== null)
+                                // 2) For each one, grab its saved state, look up the latest spec, and construct an Equipment
+                                .map((slot) => {
+                                        const state = slot.itemState!; // { id, quantity, rarity }
+                                        return Equipment.createFromState(state);
+                                })
+                );
+        }
+
+        /** Award renown to all equipped items */
+        public awardRenownToEquipped(amount: number) {
+                for (const slot of this.slots) {
+                        if (slot.type === "equipment" && slot.itemState) {
+                                const eq = Equipment.createFromState(slot.itemState);
+                                eq.addRenown(amount);
+                        }
+                }
+        }
 
 	private emitChange() {
 		bus.emit("inventory:changed");

--- a/src/features/inventory/InventoryRegistry.ts
+++ b/src/features/inventory/InventoryRegistry.ts
@@ -21,12 +21,14 @@ export class InventoryRegistry {
 		if (!spec) {
 			throw new Error(`No spec registered for item ID "${id}"`);
 		}
-		const baseState: InventoryItemState = {
-			specId: id,
-			quantity,
-			rarity: BalanceCalculators.getItemRarity(),
-			heirloom: 0,
-		};
+                const baseState: InventoryItemState = {
+                        specId: id,
+                        quantity,
+                        rarity: BalanceCalculators.getItemRarity(),
+                        heirloom: 0,
+                        renown: 0,
+                        renownRequired: (spec as any).baseRenown ?? 100,
+                };
 		if (spec.category === "equipment") {
 			return {
 				...baseState,

--- a/src/models/OfflineProgress.ts
+++ b/src/models/OfflineProgress.ts
@@ -306,8 +306,9 @@ class HuntOfflineHandler implements OfflineProgressHandler {
 		const renownGained = kills * area.tier;
 		const xpGained = kills * area.getXpPerKill(false);
 
-		context.player.adjustRenown(renownGained);
-		context.character.gainXp(xpGained);
+                context.player.adjustRenown(renownGained);
+                context.inventory.awardRenownToEquipped(renownGained);
+                context.character.gainXp(xpGained);
 
 		const chests = this.treasure.calculateTreasureRewards(offlineSeconds);
 		if (chests.chestsEarned > 0) {

--- a/src/models/PrestigeManager.ts
+++ b/src/models/PrestigeManager.ts
@@ -21,9 +21,9 @@ export class PrestigeManager {
 
 			// 2. Apply persistent rewards
 			context.settlement.modifyBuildPoints(buildPoints);
-			for (const equipment of context.inventory.getEquippedEquipment()) {
-				equipment.addHeirloom(1);
-			}
+                        for (const equipment of context.inventory.getEquippedEquipment()) {
+                                equipment.tryPrestigeUpgrade();
+                        }
 			//context.player.updatePrestigeStats();
 
 			// 3. Trigger prestige events

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -266,10 +266,11 @@ export interface InventoryItemSpec extends Identifiable {
 }
 
 export interface EquipmentItemSpec extends InventoryItemSpec {
-	category: "equipment";
-	equipType: EquipmentType;
-	statMod: StatsModifier;
-	resistances?: Partial<Resistances>;
+        category: "equipment";
+        equipType: EquipmentType;
+        statMod: StatsModifier;
+        resistances?: Partial<Resistances>;
+        baseRenown: number;
 }
 
 export interface ResourceItemSpec extends InventoryItemSpec {
@@ -290,8 +291,10 @@ export interface InventoryItemState {
 	status?: ItemEquipStatus;
 	level?: number;
 	progress?: number;
-	rarity?: ItemRarity;
-	heirloom?: number;
+        rarity?: ItemRarity;
+        heirloom?: number;
+        renown?: number;
+        renownRequired?: number;
 }
 
 export function getItemCategoryLabel(category: ItemCategory): string {

--- a/src/ui/components/InventorySlot.ts
+++ b/src/ui/components/InventorySlot.ts
@@ -38,14 +38,16 @@ export class InventorySlot extends UIBase {
 		if (!this.itemState || !this.spec) return;
 
 		// Common tooltip data
-		const baseTooltip = {
-			icon: this.spec.iconUrl,
-			name: `Lvl:${this.itemState.level} - ${prettify(this.spec.name)}`,
-			rarity: prettify(this.itemState.rarity!),
-			type: getItemCategoryLabel(this.spec.category),
-			tintColour: this.itemState.rarity,
-			heirloom: this.itemState.heirloom,
-		};
+                const baseTooltip = {
+                        icon: this.spec.iconUrl,
+                        name: `Lvl:${this.itemState.level} - ${prettify(this.spec.name)}`,
+                        rarity: prettify(this.itemState.rarity!),
+                        type: getItemCategoryLabel(this.spec.category),
+                        tintColour: this.itemState.rarity,
+                        heirloom: this.itemState.heirloom,
+                        renownCurrent: this.itemState.renown,
+                        renownRequired: this.itemState.renownRequired,
+                };
 
 		// TODO: This is a hack to get the stat modifiers for equipment
 		// TODO: We should have a better way to do this

--- a/src/ui/components/Tooltip.ts
+++ b/src/ui/components/Tooltip.ts
@@ -4,15 +4,17 @@ export interface TooltipListItem {
 }
 
 export interface TooltipData {
-	icon: string;
-	name: string;
-	rarity?: string;
-	type?: string;
-	stats?: string[];
-	heirloom?: number;
-	description?: string;
-	tintColour?: string;
-	list?: (string | TooltipListItem)[];
+        icon: string;
+        name: string;
+        rarity?: string;
+        type?: string;
+        stats?: string[];
+        heirloom?: number;
+        renownCurrent?: number;
+        renownRequired?: number;
+        description?: string;
+        tintColour?: string;
+        list?: (string | TooltipListItem)[];
 }
 
 export class Tooltip {
@@ -34,8 +36,9 @@ export class Tooltip {
 				<img class="tooltip-icon" />
 				<h3 class="tooltip-name"></h3>
 			</header>
-			<p class="tooltip-type"></p>
-			<p class="tooltip-heirloom"></p>
+                        <p class="tooltip-type"></p>
+                        <p class="tooltip-heirloom"></p>
+                        <p class="tooltip-renown"></p>
 			<ul class="tooltip-stats"></ul>
 			<p class='tooltip-description'></p>
 			<ul class='tooltip-list'></ul>
@@ -56,8 +59,12 @@ export class Tooltip {
 		this.$(".tooltip-name").textContent = data.name;
 		this.$(".tooltip-type").textContent = `${data.type ?? ""} • ${data.rarity ?? ""}`.trim();
 		this.fillStats(data.stats ?? []);
-		this.$(".tooltip-heirloom").textContent = data.heirloom ? `Heirloom: ${data.heirloom}` : "";
-		this.$(".tooltip-description").textContent = data.description ?? "";
+                this.$(".tooltip-heirloom").textContent = data.heirloom ? `Heirloom: ${data.heirloom}` : "";
+                this.$(".tooltip-renown").textContent =
+                        data.renownCurrent !== undefined && data.renownRequired !== undefined
+                                ? `Renown: ${data.renownCurrent} / ${data.renownRequired}`
+                                : "";
+                this.$(".tooltip-description").textContent = data.description ?? "";
 		this.fillList(data.list ?? []);
 
 		// Optional tint


### PR DESCRIPTION
## Summary
- add baseRenown field to equipment specs
- include renown tracking properties in item state
- manage renown accumulation and prestige upgrades on equipment
- show renown progress in tooltips
- award renown to equipped items on kills and offline progress

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687363c5e4a88330b504ec0b56c758ee