### PR TITLE
Add recruit assignment to BuildingStatus

### DIFF
--- a/css/UIComponents.css
+++ b/css/UIComponents.css
@@ -629,13 +629,41 @@ section + section {
 
 /* Building Status */
 .building-status {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	padding: 0.5rem 1rem;
-	background: rgba(32, 32, 32, 0.719);
-	border-radius: 12px;
-	margin-bottom: 1rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 0.5rem 1rem;
+        background: rgba(32, 32, 32, 0.719);
+        border-radius: 12px;
+        margin-bottom: 1rem;
+}
+
+.recruit-portrait {
+        width: 48px;
+        height: 48px;
+        border-radius: 50%;
+        border: 2px solid var(--recruit-border, #888);
+        margin-right: 0.5rem;
+        cursor: pointer;
+        object-fit: cover;
+}
+.recruit-portrait.rarity-common {
+        --recruit-border: #888;
+}
+.recruit-portrait.rarity-uncommon {
+        --recruit-border: #4caf50;
+}
+.recruit-portrait.rarity-rare {
+        --recruit-border: #2196f3;
+}
+.recruit-portrait.rarity-epic {
+        --recruit-border: #9c27b0;
+}
+.recruit-portrait.rarity-legendary {
+        --recruit-border: #ff99008e;
+}
+.recruit-portrait.rarity-unique {
+        --recruit-border: #e91e63;
 }
 
 .mh-progress-container {

--- a/src/ui/components/BuildingStatus.ts
+++ b/src/ui/components/BuildingStatus.ts
@@ -1,23 +1,31 @@
 import { Building } from "@/features/settlement/Building";
 import { UIBase } from "./UIBase";
 import { bus } from "@/core/EventBus";
+import profileImg from "@/Assets/Images/player-profile.png";
+import { GenericModal } from "./GenericModal";
 
 export class BuildingStatus extends UIBase {
-	private levelEl!: HTMLElement;
-	private allocatedEl!: HTMLElement;
-	private requiredEl!: HTMLElement;
-	constructor(private container: HTMLElement, private building: Building) {
+        private levelEl!: HTMLElement;
+        private allocatedEl!: HTMLElement;
+        private requiredEl!: HTMLElement;
+        private portraitEl!: HTMLImageElement;
+        constructor(private container: HTMLElement, private building: Building) {
 		super();
 		const root = document.createElement("div");
 		root.classList.add("basic-section-header");
 		this.element = root;
 
-		const nameEl = document.createElement("span");
-		nameEl.textContent = building.displayName;
-		nameEl.classList.add("basic-title");
-		const infoContainer = document.createElement("div");
-		root.appendChild(nameEl);
-		root.append(infoContainer);
+                this.portraitEl = document.createElement("img");
+                this.portraitEl.className = "recruit-portrait";
+                this.portraitEl.addEventListener("click", () => this.openRecruitMenu());
+
+                const nameEl = document.createElement("span");
+                nameEl.textContent = building.displayName;
+                nameEl.classList.add("basic-title");
+                const infoContainer = document.createElement("div");
+                root.appendChild(this.portraitEl);
+                root.appendChild(nameEl);
+                root.append(infoContainer);
 
 		this.levelEl = document.createElement("span");
 		this.allocatedEl = document.createElement("span");
@@ -25,14 +33,84 @@ export class BuildingStatus extends UIBase {
 		infoContainer.append(this.levelEl, this.allocatedEl, this.requiredEl);
 		this.container.appendChild(root);
 
-		this.update();
-		bus.on("settlement:changed", () => this.update());
-	}
+                this.update();
+                bus.on("settlement:changed", () => this.update());
+                bus.on("recruits:changed", () => this.update());
+        }
 
-	private update() {
-		const snap = this.building.snapshot;
+        private update() {
+                const snap = this.building.snapshot;
 		this.levelEl.textContent = `Lv ${snap.level}`;
 		this.allocatedEl.textContent = `Allocated: ${snap.pointsAllocated}`;
-		this.requiredEl.textContent = `Next: ${snap.nextUnlock}`;
-	}
+                this.requiredEl.textContent = `Next: ${snap.nextUnlock}`;
+
+                const recruitId = this.building.staffId;
+                if (recruitId) {
+                        const recruit = this.context.recruits.getRecruit(recruitId);
+                        if (recruit) {
+                                this.portraitEl.src = profileImg;
+                                this.portraitEl.className = `recruit-portrait rarity-${recruit.rarity}`;
+                                this.portraitEl.title = `Bond Bonus: ${(recruit.bondBonus * 100).toFixed(0)}%`;
+                        }
+                } else {
+                        this.portraitEl.src = profileImg;
+                        this.portraitEl.className = "recruit-portrait";
+                        this.portraitEl.title = "Click to assign";
+                }
+        }
+
+        private openRecruitMenu() {
+                const recruits = this.context.recruits.getRecruits();
+                const available = recruits.filter(
+                        (r) => !r.assignedBuilding || r.assignedBuilding === this.building.id
+                );
+
+                const options = [] as { id: string; icon: string; title: string; description: string }[];
+
+                if (this.building.staffId) {
+                        options.push({
+                                id: "unassign",
+                                icon: "",
+                                title: "Unassign",
+                                description: "Remove current recruit",
+                        });
+                }
+
+                for (const r of available) {
+                        options.push({
+                                id: r.id,
+                                icon: profileImg,
+                                title: `${r.profession} (${r.id})`,
+                                description: `Bond ${r.bondXp} (+${(r.bondBonus * 100).toFixed(0)}%)`,
+                        });
+                }
+
+                const modal = new GenericModal(
+                        `Assign ${this.building.displayName}`,
+                        options,
+                        "Select",
+                        (opt) => {
+                                if (opt.id === "unassign") {
+                                        const id = this.building.staffId;
+                                        if (id) {
+                                                this.context.recruits.unassignRecruit(id);
+                                                this.building.assignStaff(null);
+                                                bus.emit("settlement:changed");
+                                        }
+                                } else {
+                                        const recruit = this.context.recruits.getRecruit(opt.id);
+                                        if (recruit) {
+                                                if (recruit.assignedBuilding && recruit.assignedBuilding !== this.building.id) {
+                                                        const prev = this.context.settlement.getBuilding(recruit.assignedBuilding);
+                                                        prev?.assignStaff(null);
+                                                }
+                                                this.context.recruits.assignRecruit(recruit.id, this.building.id);
+                                                this.building.assignStaff(recruit);
+                                                bus.emit("settlement:changed");
+                                        }
+                                }
+                        }
+                );
+                modal.show();
+        }
 }


### PR DESCRIPTION
## Summary
- show assigned recruit portrait in building status
- open a modal to assign or unassign recruits
- style recruit portrait with rarity colours

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68740b9f0ce88330badaecef3424fd7b