### PR TITLE
Persist last event payload in EventBus

### DIFF
--- a/src/core/EventBus.ts
+++ b/src/core/EventBus.ts
@@ -133,6 +133,9 @@ export class EventBus {
     emit<E extends EventKey>(event: E, payload: GameEvents[E]): void;
 
     public emit(event: EventKey, payload?: any): void {
+        // Save the payload so future listeners can immediately receive it
+        this.lastValue.set(event, payload);
+
         const set = this.listeners.get(event);
         if (!set) return;
         set.forEach((fn) => {

--- a/src/eventBus.test.ts
+++ b/src/eventBus.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventBus } from './core/EventBus';
+
+describe('EventBus lastValue behavior', () => {
+  it('invokes listener immediately with last payload when subscribing after emit', () => {
+    const bus = new EventBus();
+    const fn = vi.fn();
+
+    bus.emit('player:level-up', 3);
+    bus.on('player:level-up', fn);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith(3);
+  });
+
+  it('uses the most recent payload for new subscribers', () => {
+    const bus = new EventBus();
+    const fn = vi.fn();
+
+    bus.emit('player:level-up', 1);
+    bus.emit('player:level-up', 2);
+    bus.on('player:level-up', fn);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith(2);
+  });
+});


### PR DESCRIPTION
## Summary
- store last emitted value in `EventBus.emit`
- add tests for `EventBus` last value behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c9944f10c8330b948edcd2ddc4128