### PR TITLE
Fix offline drop chance logic

### DIFF
--- a/src/models/Area.ts
+++ b/src/models/Area.ts
@@ -111,9 +111,10 @@ export class Area extends SpecRegistryBase<AreaSpec> {
 			const selectedItem = candidates[randomIndex];
 
 			// Optional: Respect drop chance (reduced for offline to avoid too many rares)
-			const offlineDropChance = baseDropChance * 0.5; // 50% of normal drop rate for offline
-
-			ids.push(selectedItem.id);
+                        const offlineDropChance = baseDropChance * 0.5; // 50% of normal drop rate for offline
+                        if (Math.random() < offlineDropChance) {
+                                ids.push(selectedItem.id);
+                        }
 		}
 
 		return ids;

--- a/src/offlineLoot.test.ts
+++ b/src/offlineLoot.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Area, AreaSpec } from './models/Area';
+import { Equipment } from './models/Equipment';
+import { InventoryRegistry } from './features/inventory/InventoryRegistry';
+
+const equipmentSpec = {
+  id: 'test_item',
+  category: 'equipment',
+  name: 'Test Item',
+  description: '',
+  equipType: 'head',
+  statMod: {},
+  iconUrl: '',
+  resistances: {},
+  baseRenown: 0,
+  tags: ['test']
+} as any;
+
+const areaZero: AreaSpec = {
+  id: 'test_zero',
+  displayName: 'Test Area Zero',
+  tier: 1,
+  requires: [],
+  spawns: [{ monsterId: 'm1', weight: 1, drops: { tags: ['test'], baseDropChance: 0 } }],
+  boss: { monsterId: 'm1', weight: 1, drops: { tags: ['test'], baseDropChance: 1 } }
+};
+
+const areaHalf: AreaSpec = {
+  id: 'test_half',
+  displayName: 'Test Area Half',
+  tier: 1,
+  requires: [],
+  spawns: [{ monsterId: 'm1', weight: 1, drops: { tags: ['test'], baseDropChance: 1 } }],
+  boss: { monsterId: 'm1', weight: 1, drops: { tags: ['test'], baseDropChance: 1 } }
+};
+
+beforeEach(() => {
+  // Reset registries
+  (Equipment as any).specById = new Map();
+  Equipment.registerSpecs([equipmentSpec]);
+
+  (Area as any).specById = new Map();
+  Area.registerSpecs([areaZero, areaHalf]);
+
+  (InventoryRegistry as any).specMap = new Map();
+  InventoryRegistry.init();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Area.rollOfflineLoot', () => {
+  it('returns no items when drop chance is 0', () => {
+    const area = Area.create('test_zero');
+    (area as any).selectedSpawn = area.spawns[0];
+    const loot = area.rollOfflineLoot();
+    expect(loot.length).toBe(0);
+  });
+
+  it('awards items based on offline drop chance', () => {
+    const area = Area.create('test_half');
+    (area as any).selectedSpawn = area.spawns[0];
+    const rnd = vi.spyOn(Math, 'random');
+    rnd.mockReturnValueOnce(0); // numItems -> 1
+    rnd.mockReturnValueOnce(0); // randomIndex
+    rnd.mockReturnValueOnce(0.3); // drop chance < 0.5 -> success
+    const loot = area.rollOfflineLoot();
+    expect(loot).toEqual(['test_item']);
+  });
+});


### PR DESCRIPTION
## Summary
- use the offline drop chance when rolling offline loot
- add tests for offline loot drop chance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c9950fe5c833090225d2f4968f59b