### PR TITLE
Add manual milestone trigger to debug menu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -700,11 +700,14 @@ body,
 	font-size: 0.8rem;
 }
 #debug-menu .debug-option input[type="number"] {
-	width: 60px;
+        width: 60px;
+}
+#debug-menu .debug-option input[type="text"] {
+        width: 120px;
 }
 #debug-menu button {
-	font-size: 0.8rem;
-	padding: 0.25rem 0.5rem;
+        font-size: 0.8rem;
+        padding: 0.25rem 0.5rem;
 }
 
 #debug-menu .debug-column.player-stats,

--- a/src/ui/components/Debug-Menu.ts
+++ b/src/ui/components/Debug-Menu.ts
@@ -113,26 +113,47 @@ export class DebugMenu {
 		this.optionsEl.appendChild(wrap);
 	}
 
-	private addNumber(label: string, key: keyof DebugOptions, step: number) {
-		const wrap = document.createElement("label");
-		wrap.classList.add("debug-option");
-		const span = document.createElement("span");
-		span.textContent = label + ": ";
-		const input = document.createElement("input");
-		input.type = "number";
-		input.step = String(step);
-		input.value = String(debugManager.get(key));
-		input.addEventListener("change", () => {
-			debugManager.set(key, Number(input.value) as any);
-		});
-		wrap.appendChild(span);
-		wrap.appendChild(input);
-		this.optionsEl.appendChild(wrap);
-	}
+        private addNumber(label: string, key: keyof DebugOptions, step: number) {
+                const wrap = document.createElement("label");
+                wrap.classList.add("debug-option");
+                const span = document.createElement("span");
+                span.textContent = label + ": ";
+                const input = document.createElement("input");
+                input.type = "number";
+                input.step = String(step);
+                input.value = String(debugManager.get(key));
+                input.addEventListener("change", () => {
+                        debugManager.set(key, Number(input.value) as any);
+                });
+                wrap.appendChild(span);
+                wrap.appendChild(input);
+                this.optionsEl.appendChild(wrap);
+        }
 
-	private addActions() {
-		const context = GameContext.getInstance();
-		this.addButton("Save", () => context.saves.saveAll());
+        private addMilestoneTrigger() {
+                const wrap = document.createElement("label");
+                wrap.classList.add("debug-option");
+                const input = document.createElement("input");
+                input.type = "text";
+                input.placeholder = "Milestone ID";
+                const btn = document.createElement("button");
+                btn.textContent = "Trigger";
+                btn.addEventListener("click", () => {
+                        const id = input.value.trim();
+                        if (id) {
+                                MilestoneManager.instance.triggerMilestone(id);
+                                input.value = "";
+                        }
+                });
+                wrap.appendChild(input);
+                wrap.appendChild(btn);
+                this.optionsEl.appendChild(wrap);
+        }
+
+        private addActions() {
+                const context = GameContext.getInstance();
+                this.addMilestoneTrigger();
+                this.addButton("Save", () => context.saves.saveAll());
 		this.addButton("Load", () => window.location.reload()); //saveManager.loadAll());
 		this.addButton("New Game", () => context.saves.startNewGame());
 		this.addButton("New Debug Game", () => {


### PR DESCRIPTION
## Summary
- allow manual milestone triggering from the debug menu
- style new milestone input

## Testing
- `npm test` *(fails: EventBus lastValue behavior tests)*

------
https://chatgpt.com/codex/tasks/task_e_687f56696b3c8330b4c417c3c52f6ef4