### PR TITLE
Optimize upgrade refresh logic

### DIFF
--- a/src/ui/Screens/BlacksmithScreen.ts
+++ b/src/ui/Screens/BlacksmithScreen.ts
@@ -380,11 +380,11 @@ export class BlacksmithScreen extends BaseScreen {
 		});
 	}
 
-	private refreshUpgrades() {
-		if (this.upgradeContainer) {
-			this.upgradeContainer.setUpgrades(this.getUpgradeData());
-		}
-	}
+        private refreshUpgrades() {
+                if (this.upgradeContainer) {
+                        this.upgradeContainer.updateUpgrades(this.getUpgradeData());
+                }
+        }
 
 	private getUpgradeData(): UpgradeSelectionData[] {
 		return this.context.blacksmith.getUpgrades().map((upg) => ({

--- a/src/ui/Screens/LibraryScreen.ts
+++ b/src/ui/Screens/LibraryScreen.ts
@@ -167,11 +167,11 @@ export class LibraryScreen extends BaseScreen {
 		return row;
 	}
 
-	private updateUpgrades() {
-		// Update the upgrade container with latest data
-		const upgrades = this.getAvailableUpgrades();
-		this.upgradeContainer.setUpgrades(upgrades);
-	}
+        private updateUpgrades() {
+                // Update the upgrade container with latest data
+                const upgrades = this.getAvailableUpgrades();
+                this.upgradeContainer.updateUpgrades(upgrades);
+        }
 
 	private getAvailableUpgrades(): UpgradeSelectionData[] {
 		const availableResearch = this.context.library.getAvailable();

--- a/src/ui/components/UpgradeSelectionComponent.ts
+++ b/src/ui/components/UpgradeSelectionComponent.ts
@@ -28,9 +28,13 @@ export interface UpgradeSelectionComponentOptions {
 }
 
 export class UpgradeSelectionComponent extends UIBase {
-	private data: UpgradeSelectionData;
-	private progressBar?: ProgressBar;
-	private timerEl?: HTMLElement;
+        private data: UpgradeSelectionData;
+        private progressBar?: ProgressBar;
+        private timerEl?: HTMLElement;
+        private levelEl?: HTMLElement;
+        private titleEl!: HTMLElement;
+        private descEl!: HTMLElement;
+        private actionBtn!: HTMLButtonElement;
 
 	constructor(options: UpgradeSelectionComponentOptions) {
 		super();
@@ -40,21 +44,24 @@ export class UpgradeSelectionComponent extends UIBase {
 		root.className = "upgrade-card";
 		if (data.purchased) root.classList.add("purchased");
 
-		const title = document.createElement("div");
-		title.className = "upgrade-title";
-		title.textContent = data.title;
-		root.appendChild(title);
+                const title = document.createElement("div");
+                title.className = "upgrade-title";
+                title.textContent = data.title;
+                root.appendChild(title);
+                this.titleEl = title;
 
-		const desc = document.createElement("div");
-		desc.className = "upgrade-desc";
-		desc.textContent = data.description;
-		root.appendChild(desc);
+                const desc = document.createElement("div");
+                desc.className = "upgrade-desc";
+                desc.textContent = data.description;
+                root.appendChild(desc);
+                this.descEl = desc;
 
                 if (data.level !== undefined && data.maxLevel !== undefined) {
                         const level = document.createElement("div");
                         level.className = "upgrade-level";
                         level.textContent = `${data.level}/${data.maxLevel}`;
                         root.appendChild(level);
+                        this.levelEl = level;
                 }
 
 		if (data.requiredTime) {
@@ -91,10 +98,11 @@ export class UpgradeSelectionComponent extends UIBase {
 		});
 		footer.appendChild(costContainer);
 
-		const btn = document.createElement("button");
-		btn.className = "ui-button upgrade-action-btn";
-		btn.textContent = data.purchased ? "Purchased" : data.buttonOverride || "Buy";
-		if (data.purchased || data.canAfford === false) btn.disabled = true;
+                const btn = document.createElement("button");
+                btn.className = "ui-button upgrade-action-btn";
+                btn.textContent = data.purchased ? "Purchased" : data.buttonOverride || "Buy";
+                if (data.purchased || data.canAfford === false) btn.disabled = true;
+                this.actionBtn = btn;
 		if (onClick) {
 			this.bindDomEvent(btn, "click", () => onClick(data.id));
 		}
@@ -110,12 +118,36 @@ export class UpgradeSelectionComponent extends UIBase {
 		return this.data;
 	}
 
-	public updateProgress(value: number) {
-		if (!this.progressBar) return;
-		this.data.progress = value;
-		this.progressBar.setValue(value);
-		this.updateTimer();
-	}
+        public updateProgress(value: number) {
+                if (!this.progressBar) return;
+                this.data.progress = value;
+                this.progressBar.setValue(value);
+                this.updateTimer();
+        }
+
+        public update(data: UpgradeSelectionData) {
+                this.data = { ...data };
+                this.titleEl.textContent = data.title;
+                this.descEl.textContent = data.description;
+                if (this.levelEl && data.level !== undefined && data.maxLevel !== undefined) {
+                        this.levelEl.textContent = `${data.level}/${data.maxLevel}`;
+                }
+
+                if (this.progressBar && data.requiredTime !== undefined) {
+                        this.progressBar.setMax(data.requiredTime);
+                        this.updateProgress(data.progress ?? 0);
+                }
+
+                if (data.purchased) {
+                        this.element.classList.add("purchased");
+                        this.actionBtn.textContent = "Purchased";
+                        this.actionBtn.disabled = true;
+                } else {
+                        this.element.classList.remove("purchased");
+                        this.actionBtn.textContent = data.buttonOverride || "Buy";
+                        this.actionBtn.disabled = data.canAfford === false;
+                }
+        }
 
 	private updateTimer() {
 		if (!this.timerEl || this.data.requiredTime === undefined) return;

--- a/src/ui/components/UpgradeSelectionContainer.ts
+++ b/src/ui/components/UpgradeSelectionContainer.ts
@@ -72,6 +72,37 @@ export class UpgradeSelectionContainer extends UIBase {
         this.applyFilters();
     }
 
+    public updateUpgrades(upgrades: UpgradeSelectionData[]) {
+        this.upgrades = upgrades;
+        const byId = new Map<string, UpgradeSelectionData>();
+        upgrades.forEach((u) => byId.set(u.id, u));
+
+        // Update or remove existing components
+        this.components.forEach((comp, id) => {
+            const data = byId.get(id);
+            if (data) {
+                comp.update(data);
+            } else {
+                comp.destroy();
+                this.components.delete(id);
+            }
+        });
+
+        // Add new components
+        upgrades.forEach((u) => {
+            if (!this.components.has(u.id)) {
+                const comp = new UpgradeSelectionComponent({
+                    parent: this.gridEl,
+                    data: u,
+                    onClick: this.onUpgradeClick,
+                });
+                this.components.set(u.id, comp);
+            }
+        });
+
+        this.applyFilters();
+    }
+
     private applyFilters() {
         const showPurchased = this.filterPurchased.checked;
         const showUnaffordable = this.filterAffordable.checked;


### PR DESCRIPTION
## Summary
- update `UpgradeSelectionComponent` to allow updating existing cards
- add `updateUpgrades` method in `UpgradeSelectionContainer`
- refresh upgrades without recreating them in Blacksmith and Library screens

## Testing
- `npm test` *(fails: EventBus lastValue behavior tests)*

------
https://chatgpt.com/codex/tasks/task_e_6880db7328908330b256441431166574